### PR TITLE
Generate genesis in hlf-ord chart

### DIFF
--- a/charts/hlf-k8s/requirements.lock
+++ b/charts/hlf-k8s/requirements.lock
@@ -3,13 +3,13 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.1.8
 - name: hlf-ord
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.2.6
+  repository: file:///home/aurelien/code/charts/stable/hlf-ord
+  version: 1.3.1
 - name: hlf-peer
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.2.10
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.20.0
-digest: sha256:e78346469f70cb308318b6ee5b91631198f90d3c76a57e4a1e33428df02346b6
-generated: "2019-09-12T16:08:01.429288721+02:00"
+digest: sha256:7323ccd50bf6fac693a6ee10dc683f9e258fe878e689b768f1216da0d8aa9eee
+generated: "2019-11-14T16:38:19.643215094-05:00"

--- a/charts/hlf-k8s/requirements.yaml
+++ b/charts/hlf-k8s/requirements.yaml
@@ -19,8 +19,8 @@ dependencies:
     alias: ca
     condition: ca.enabled
   - name: hlf-ord
-    repository: https://kubernetes-charts.storage.googleapis.com/
-    version: ~1.2.5
+    repository: file:///home/aurelien/code/charts/stable/hlf-ord
+    version: 1.3.1
     condition: orderer.enabled
     alias: orderer
   - name: hlf-peer

--- a/charts/hlf-k8s/templates/job-generate-genesis.yaml
+++ b/charts/hlf-k8s/templates/job-generate-genesis.yaml
@@ -45,8 +45,8 @@ spec:
         command: ['sh', '-c']
         args:
           - |
-            generate-genesis.sh {{ .Values.systemChannel }} {{ .Values.secrets.genesis }}
-            kubectl delete pods -l app=orderer,release={{ .Release.Name }}
+            # generate-genesis.sh {{ .Values.systemChannel }} {{ .Values.secrets.genesis }}
+            # kubectl delete pods -l app=orderer,release={{ .Release.Name }}
         env:
         - name: CORE_PEER_MSPCONFIGPATH
           value: /var/hyperledger/admin_msp

--- a/charts/hlf-k8s/templates/job-hook-cleanup.yaml
+++ b/charts/hlf-k8s/templates/job-hook-cleanup.yaml
@@ -61,7 +61,7 @@ spec:
           - {{ .Values.secrets.ordTlsRootCert }}
           - {{ .Values.secrets.orgConfig }}
           - {{ .Values.secrets.orgConfig }}-anchor
-          - {{ .Values.secrets.genesis }}
+          # - {{ .Values.secrets.genesis }}
           - {{ .Values.secrets.adminKey }}
           {{- range .Values.fetchSecrets }}
           - {{ .to }}

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -127,6 +127,12 @@ orderer:
         enabled: "true"
       client:
         enabled: "true"
+    genesis:
+      generate:
+        enabled: true
+        profile: OrgsOrdererGenesis
+        channelID: systemchannel
+        configMap: hlf-k8s-fabric
   secrets:
     ## These secrets should contain the Orderer crypto materials and credentials
     ord:


### PR DESCRIPTION
Companion PR: https://github.com/AurelienGasser/charts/pull/1

---

To test it locally:

**Bootstrap**

1. clone/package my fork

```bash
git clone https://github.com/AurelienGasser/charts.git
git checkout hlf-ord-generate-genesis
cd charts/stable/hlf-ord
helm package .
```

2. update your `requirements.{yaml,lock}`

```bash
cd hlf-k8s/charts/hlf-k8s
vim requirements.yaml  # update the file:/// reference to point to your local clone
helm dep update        # re-generate requirements.lock
```

**Test**

After you do any change to the hlf-ord charts:

1. re-package the chart

```bash
cd charts/stable/hlf-ord
helm package .
```

2. re-run skaffold dev

```bash
cd hlf-k8s
skaffold dev
```