### PR TITLE
chaincode: support local filepath for chaincode source code (in addition to archive URL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ To use a custom chaincode locally, change the `chaincodes.src` values in [`skaff
  - `deploy.helm.realease.name[network-peer-1].setValues.chaincodes[0].src: /home/johndoe/code/substra-chaincode`
  - `deploy.helm.realease.name[network-peer-2].setValues.chaincodes[0].src: /home/johndoe/code/substra-chaincode`
 
+The chaincode path must be accessible from your kubernetes cluster. For instance, on a running minikube, you need to run `nohup minikube mount <chaincode-absolute-path>:<chaincode-absolute-path> &`.
+
 ## substra-backend
 
 A backend is available named substra-backend which can interact with this ledger.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,10 @@ To use a custom chaincode locally, change the `chaincodes.src` values in [`skaff
  - `deploy.helm.realease.name[network-peer-1].setValues.chaincodes[0].src: /home/johndoe/code/substra-chaincode`
  - `deploy.helm.realease.name[network-peer-2].setValues.chaincodes[0].src: /home/johndoe/code/substra-chaincode`
 
-The chaincode path must be accessible from your kubernetes cluster. For instance, on a running minikube, you need to run `nohup minikube mount <chaincode-absolute-path>:<chaincode-absolute-path> &`.
+The chaincode path must be accessible from your kubernetes cluster:
+
+- On Docker for Mac, go to Settings > File Sharing and make sure the chaincode folder is included in the mounted folders
+- On a running minikube instance, run `nohup minikube mount <chaincode-absolute-path>:<chaincode-absolute-path> &`
 
 ## substra-backend
 

--- a/README.md
+++ b/README.md
@@ -109,18 +109,9 @@ then head to `http://localhost/`
 
 By default, the `skaffold dev` command will start a substra network that uses the default [susbtra-chaincode](https://github.com/SubstraFoundation/substra-chaincode).
 
-If you want to use a custom chaincode locally, follow these steps:
-
-1. Make a `tar.gz` archive of your chaincode accessible from the substra network. The easiest way is to use Github:
-   - Push your local, custom branch of [susbtra-chaincode](https://github.com/SubstraFoundation/substra-chaincode) to a fork on your github account, e.g. https://github.com/my-github-account/substra-chaincode/my-branch
-     - /!\ The branch name cannot contain the `/` character (that's a Hyperledger Fabric limitation)
-   - The archive will now be available on https://github.com/my-github-account/substra-chaincode/archive/my-branch.tar.gz
-2. In [`skaffold.yaml`](./skaffold.yaml), update the chaincode `src`:
-   - `deploy.helm.realease.name[network-peer-1].setValues.chaincodes[0].src`: should point to https://github.com/my-github-account/substra-chaincode/archive/my-branch.tar.gz
-   - `deploy.helm.realease.name[network-peer-2].setValues.chaincodes[0].src`: same thing
-3. Start the network: `skaffold dev`. 
-   
-This substra network will use your custom chaincode.
+To use a custom chaincode locally, change the `chaincodes.src` values in [`skaffold.yaml`](./skaffold.yaml) to point to your local clone of the [susbtra-chaincode](https://github.com/SubstraFoundation/substra-chaincode), e.g.
+ - `deploy.helm.realease.name[network-peer-1].setValues.chaincodes[0].src: /home/johndoe/code/substra-chaincode`
+ - `deploy.helm.realease.name[network-peer-2].setValues.chaincodes[0].src: /home/johndoe/code/substra-chaincode`
 
 ## substra-backend
 

--- a/charts/hlf-k8s/templates/job-chaincode-install.yaml
+++ b/charts/hlf-k8s/templates/job-chaincode-install.yaml
@@ -47,11 +47,7 @@ spec:
         args:
           - {{ .name | quote }}
           - {{ .version | quote }}
-          {{- if .srcPath }}
-          - {{ .srcPath | quote}}
-          {{- else }}
           - {{ .src | quote}}
-          {{- end }}
         env:
         - name: CORE_PEER_MSPCONFIGPATH
           value: /var/hyperledger/admin_msp
@@ -93,8 +89,8 @@ spec:
           name: cacert
         - mountPath: /var/hyperledger/admin_msp/admincerts
           name: admin-cert
-        {{- if .srcPath }}
-        - mountPath: {{ .srcPath }}
+        {{- if ne "http" (regexFind "^http" .src) }}
+        - mountPath: {{ .src }}
           name: chaincode-local-src
         {{- end }}
       volumes:
@@ -131,10 +127,10 @@ spec:
       - name: ord-tls-rootcert
         secret:
           secretName: {{ $.Values.secrets.ordTlsRootCert }}
-      {{- if .srcPath }}
+      {{- if ne "http" (regexFind "^http" .src) }}
       - name: chaincode-local-src
         hostPath:
-          path: {{ .srcPath }}
+          path: {{ .src }}
       {{- end }}
     {{- with $.Values.nodeSelector }}
       nodeSelector:

--- a/charts/hlf-k8s/templates/job-chaincode-install.yaml
+++ b/charts/hlf-k8s/templates/job-chaincode-install.yaml
@@ -47,7 +47,11 @@ spec:
         args:
           - {{ .name | quote }}
           - {{ .version | quote }}
+          {{- if .srcPath }}
+          - {{ .srcPath | quote}}
+          {{- else }}
           - {{ .src | quote}}
+          {{- end }}
         env:
         - name: CORE_PEER_MSPCONFIGPATH
           value: /var/hyperledger/admin_msp
@@ -89,6 +93,10 @@ spec:
           name: cacert
         - mountPath: /var/hyperledger/admin_msp/admincerts
           name: admin-cert
+        {{- if .srcPath }}
+        - mountPath: {{ .srcPath }}
+          name: chaincode-local-src
+        {{- end }}
       volumes:
       - name: fabric-config
         configMap:
@@ -123,6 +131,11 @@ spec:
       - name: ord-tls-rootcert
         secret:
           secretName: {{ $.Values.secrets.ordTlsRootCert }}
+      {{- if .srcPath }}
+      - name: chaincode-local-src
+        hostPath:
+          path: {{ .srcPath }}
+      {{- end }}
     {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -168,12 +168,13 @@ chaincodes: []
   # -
   #   name: mycc
   #   version: "1.0"
-  ##  Use a chaincode accessible from the internet (see also: srcPath)
+  ##  The chaincode source code. It can be either:
+  ##  - The absolute path to the source code on your local machine. (Note for minikube users: 
+  ##    this path must be mounted in minikube, see https://stackoverflow.com/a/53251666/1370722)
+  ##  - The URL of a tar gzipped archive of the chaincode source code, accessible from the 
+  ##    internet. /!\ The archive name cannot contain the `/` character.
+  #   src: /home/johndoe/code/susbtra-chaincode
   #   src: https://github.com/SubstraFoundation/substra-chaincode/archive/0.0.2.tar.gz
-  ##  The absolute path to the chaincode source code, for development (see also: src)
-  ##    (Note for minikube users: this path must be mounted in minikube, see be under 
-  ##     the current user's home directory, see https://stackoverflow.com/a/53251666/1370722)
-  #   srcPath: /home/johndoe/code/substra-chaincode/
   #   instantiate: false
   #   policy: OR('Org1MSP.member')"
 

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -168,7 +168,12 @@ chaincodes: []
   # -
   #   name: mycc
   #   version: "1.0"
+  ##  Use a chaincode accessible from the internet (see also: srcPath)
   #   src: https://github.com/SubstraFoundation/substra-chaincode/archive/0.0.2.tar.gz
+  ##  The absolute path to the chaincode source code, for development (see also: src)
+  ##    (Note for minikube users: this path must be mounted in minikube, see be under 
+  ##     the current user's home directory, see https://stackoverflow.com/a/53251666/1370722)
+  #   srcPath: /home/johndoe/code/substra-chaincode/
   #   instantiate: false
   #   policy: OR('Org1MSP.member')"
 

--- a/images/hlf-k8s/bin/chaincode-install.sh
+++ b/images/hlf-k8s/bin/chaincode-install.sh
@@ -20,7 +20,7 @@ help() {
     echo "Arguments:"
     echo -e "\t- CHAINCODE_NAME Chaincode name (required)"
     echo -e "\t- CHAINCODE_VERSION Chaincode version (required)"
-    echo -e "\t- CHAINCODE_SRC Chaincode release archive url (required)"
+    echo -e "\t- CHAINCODE_SRC Chaincode release archive url or absolute fs path (required)"
     echo ""
     echo "Options:"
     echo -e "-h Help!"
@@ -48,16 +48,26 @@ function installChaincode() {
     if [ $? -eq 0 ]; then
         echo "Chaincode already exists. Skipping."
     else
-      if [[ -z "${GITHUB_TOKEN}" ]]; then
-        curl -L $CHAINCODE_SRC -o chaincode.tar.gz
+      if [[ $CHAINCODE_SRC == /* ]];
+      then
+        echo "Installing chaincode from path \"$CHAINCODE_SRC\"..."
+        mkdir -p /opt/gopath/src/chaincode
+        cp -R $CHAINCODE_SRC/chaincode/* /opt/gopath/src/chaincode
+        [[ $? -ne 0 ]] && echo "Error. Exiting." && exit 1
       else
-        curl --header "Authorization: token $GITHUB_TOKEN" -L $CHAINCODE_SRC -o chaincode.tar.gz
+        echo "Installing chaincode from URL \"$CHAINCODE_SRC\"..."
+        if [[ -z "${GITHUB_TOKEN}" ]]; then
+          curl -L $CHAINCODE_SRC -o chaincode.tar.gz
+        else
+          curl --header "Authorization: token $GITHUB_TOKEN" -L $CHAINCODE_SRC -o chaincode.tar.gz
+        fi
+
+        mkdir substra-chaincode
+        tar -C substra-chaincode -xvzf chaincode.tar.gz --strip-components=1
+        mkdir -p /opt/gopath/src/github.com/hyperledger
+        mv substra-chaincode/chaincode /opt/gopath/src/chaincode
       fi
 
-      mkdir substra-chaincode
-      tar -C substra-chaincode -xvzf chaincode.tar.gz --strip-components=1
-      mkdir -p /opt/gopath/src/github.com/hyperledger
-      mv substra-chaincode/chaincode /opt/gopath/src/chaincode
       peer chaincode install -n $CHAINCODE_NAME -v $CHAINCODE_VERSION -p chaincode
     fi
 }

--- a/images/hlf-k8s/bin/chaincode-install.sh
+++ b/images/hlf-k8s/bin/chaincode-install.sh
@@ -20,7 +20,7 @@ help() {
     echo "Arguments:"
     echo -e "\t- CHAINCODE_NAME Chaincode name (required)"
     echo -e "\t- CHAINCODE_VERSION Chaincode version (required)"
-    echo -e "\t- CHAINCODE_SRC Chaincode release archive url or absolute fs path (required)"
+    echo -e "\t- CHAINCODE_SRC Chaincode source code absolute path or archive URL (tar.gz) (required)"
     echo ""
     echo "Options:"
     echo -e "-h Help!"
@@ -48,13 +48,8 @@ function installChaincode() {
     if [ $? -eq 0 ]; then
         echo "Chaincode already exists. Skipping."
     else
-      if [[ $CHAINCODE_SRC == /* ]];
+      if [[ $CHAINCODE_SRC == http* ]];
       then
-        echo "Installing chaincode from path \"$CHAINCODE_SRC\"..."
-        mkdir -p /opt/gopath/src/chaincode
-        cp -R $CHAINCODE_SRC/chaincode/* /opt/gopath/src/chaincode
-        [[ $? -ne 0 ]] && echo "Error. Exiting." && exit 1
-      else
         echo "Installing chaincode from URL \"$CHAINCODE_SRC\"..."
         if [[ -z "${GITHUB_TOKEN}" ]]; then
           curl -L $CHAINCODE_SRC -o chaincode.tar.gz
@@ -66,6 +61,11 @@ function installChaincode() {
         tar -C substra-chaincode -xvzf chaincode.tar.gz --strip-components=1
         mkdir -p /opt/gopath/src/github.com/hyperledger
         mv substra-chaincode/chaincode /opt/gopath/src/chaincode
+      else
+        echo "Installing chaincode from path \"$CHAINCODE_SRC\"..."
+        mkdir -p /opt/gopath/src/chaincode
+        cp -R $CHAINCODE_SRC/chaincode/* /opt/gopath/src/chaincode
+        [[ $? -ne 0 ]] && echo "Error. Exiting." && exit 1
       fi
 
       peer chaincode install -n $CHAINCODE_NAME -v $CHAINCODE_VERSION -p chaincode

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -68,6 +68,7 @@ deploy:
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
           chaincodes[0].policy: OR("MyOrg1MSP.member"\,"MyOrg2MSP.member")
+          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/dev.tar.gz
           channels[0].name: mychannel
           channels[0].create: true
@@ -102,6 +103,7 @@ deploy:
           peer.peer.mspID: MyOrg2MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
+          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/dev.tar.gz
           channels[0].name: mychannel
           channels[0].join: true

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -69,6 +69,7 @@ deploy:
           chaincodes[0].version: "1.0"
           chaincodes[0].policy: OR("MyOrg1MSP.member"\,"MyOrg2MSP.member")
           # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
+          #       This path must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/dev.tar.gz
           channels[0].name: mychannel
           channels[0].create: true
@@ -104,6 +105,7 @@ deploy:
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
           # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
+          #       This path folder must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/dev.tar.gz
           channels[0].name: mychannel
           channels[0].join: true


### PR DESCRIPTION
The network currently downloads the chaincode source code from the public internet on each startup.

This PR allows developers to instruct hlf-k8s to fetch the chaincode source code from a local folder.

This can be useful to test local chaincode changes. This also allows developers to start the network without an internet acccess.