### PR TITLE
Remove pre-opensourcing Github Token

### DIFF
--- a/charts/hlf-k8s/templates/job-chaincode-install.yaml
+++ b/charts/hlf-k8s/templates/job-chaincode-install.yaml
@@ -53,8 +53,6 @@ spec:
           value: /var/hyperledger/admin_msp
         - name: GODEBUG
           value: "netdns=go+1"
-        - name: GITHUB_TOKEN
-          value: 82943306e1c1408d3b4a78e33bfbac58ca4b798a
         volumeMounts:
         - mountPath: /etc/hyperledger/fabric
           name: fabric-config


### PR DESCRIPTION
As reported by @AurelienGasser on slack, there is a github token left in the code (https://owkin.slack.com/archives/GEEGYPC2C/p1574331329001600)