### PR TITLE
Templatize the ca pod selector

### DIFF
--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 1.0.0-alpha.10
+version: 1.0.0-alpha.11
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/templates/job-bootstrap-orderer.yaml
+++ b/charts/hlf-k8s/templates/job-bootstrap-orderer.yaml
@@ -46,7 +46,7 @@ spec:
           args:
             - |
               bootstrap.sh \
-                "app=ca,release={{ .Release.Name }}" \
+                "app={{ .Values.ca.appSelector }},release={{ .Release.Name }}" \
                 {{ .Values.users.admin.username | quote }} \
                 {{ .Values.users.admin.password | quote }} \
                 "admin=true:ecert" \

--- a/charts/hlf-k8s/templates/job-bootstrap-peer.yaml
+++ b/charts/hlf-k8s/templates/job-bootstrap-peer.yaml
@@ -44,7 +44,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["bootstrap.sh"]
           args:
-            - "app=ca,release={{ .Release.Name }}"
+            - "app={{ .Values.ca.appSelector }},release={{ .Release.Name }}"
             - {{ .Values.users.admin.username | quote }}
             - {{ .Values.users.admin.password | quote }}
             - "hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -42,6 +42,7 @@ organization:
 
 ca:
   enabled: true
+  appSelector: hlf-ca
   image:
     tag: 1.4.2
   caName: rca
@@ -169,9 +170,9 @@ chaincodes: []
   #   name: mycc
   #   version: "1.0"
   ##  The chaincode source code. It can be either:
-  ##  - The absolute path to the source code on your local machine. (Note for minikube users: 
+  ##  - The absolute path to the source code on your local machine. (Note for minikube users:
   ##    this path must be mounted in minikube, see https://stackoverflow.com/a/53251666/1370722)
-  ##  - The URL of a tar gzipped archive of the chaincode source code, accessible from the 
+  ##  - The URL of a tar gzipped archive of the chaincode source code, accessible from the
   ##    internet. /!\ The archive name cannot contain the `/` character.
   #   src: /home/johndoe/code/susbtra-chaincode
   #   src: https://github.com/SubstraFoundation/substra-chaincode/archive/0.0.2.tar.gz


### PR DESCRIPTION
It looks like something changed in Helm or Tiller, the `app` label is no more referenced as `ca` but `hlf-ca` even with the label put in place. I couldn't find the exact change on helm tho.