### PR TITLE
Fix boostrap binaries.

### DIFF
--- a/images/hlf-k8s/setup-hfc-binaries.sh
+++ b/images/hlf-k8s/setup-hfc-binaries.sh
@@ -32,73 +32,32 @@ export MARCH=$(uname -m)
 BINARY_FILE=hyperledger-fabric-${ARCH}-${VERSION}.tar.gz
 CA_BINARY_FILE=hyperledger-fabric-ca-${ARCH}-${CA_VERSION}.tar.gz
 
-# Incrementally downloads the .tar.gz file locally first, only decompressing it
-# after the download is complete. This is slower than binaryDownload() but
-# allows the download to be resumed.
-binaryIncrementalDownload() {
-      local BINARY_FILE=$1
-      local URL=$2
-      curl -f -s -C - ${URL} -o ${BINARY_FILE} || rc=$?
-      # Due to limitations in the current Nexus repo:
-      # curl returns 33 when there's a resume attempt with no more bytes to download
-      # curl returns 2 after finishing a resumed download
-      # with -f curl returns 22 on a 404
-      if [ "$rc" = 22 ]; then
-	  # looks like the requested file doesn't actually exist so stop here
-	  return 22
-      fi
-      if [ -z "$rc" ] || [ $rc -eq 33 ] || [ $rc -eq 2 ]; then
-          # The checksum validates that RC 33 or 2 are not real failures
-          echo "==> File downloaded. Verifying the md5sum..."
-          localMd5sum=$(md5sum ${BINARY_FILE} | awk '{print $1}')
-          remoteMd5sum=$(curl -s ${URL}.md5)
-          if [ "$localMd5sum" == "$remoteMd5sum" ]; then
-              echo "==> Extracting ${BINARY_FILE}..."
-              tar xzf ./${BINARY_FILE} --overwrite
-	      echo "==> Done."
-              rm -f ${BINARY_FILE} ${BINARY_FILE}.md5
-          else
-              echo "Download failed: the local md5sum is different from the remote md5sum. Please try again."
-              rm -f ${BINARY_FILE} ${BINARY_FILE}.md5
-              exit 1
-          fi
-      else
-          echo "Failure downloading binaries (curl RC=$rc). Please try again and the download will resume from where it stopped."
-          exit 1
-      fi
-}
-
-# This will attempt to download the .tar.gz all at once, but will trigger the
-# binaryIncrementalDownload() function upon a failure, allowing for resume
-# if there are network failures.
-binaryDownload() {
-      local BINARY_FILE=$1
-      local URL=$2
-      echo "===> Downloading: " ${URL}
-      # Check if a previous failure occurred and the file was partially downloaded
-      if [ -e ${BINARY_FILE} ]; then
-          echo "==> Partial binary file found. Resuming download..."
-          binaryIncrementalDownload ${BINARY_FILE} ${URL}
-      else
-          curl ${URL} | tar xz || rc=$?
-          if [ ! -z "$rc" ]; then
-              echo "==> There was an error downloading the binary file. Switching to incremental download."
-              echo "==> Downloading file..."
-              binaryIncrementalDownload ${BINARY_FILE} ${URL}
-	  else
-	      echo "==> Done."
-          fi
-      fi
+# This will download the .tar.gz
+download() {
+    local BINARY_FILE=$1
+    local URL=$2
+    echo "===> Downloading: " "${URL}"
+    wget "${URL}" || rc=$?
+    tar xvzf "${BINARY_FILE}" || rc=$?
+    rm "${BINARY_FILE}"
+    if [ -n "$rc" ]; then
+        echo "==> There was an error downloading the binary file."
+        return 22
+    else
+        echo "==> Done."
+    fi
 }
 
 binariesInstall() {
   echo "===> Downloading version ${CA_TAG} platform specific fabric-ca-client binary"
-  binaryDownload ${CA_BINARY_FILE} https://nexus.hyperledger.org/content/repositories/releases/org/hyperledger/fabric-ca/hyperledger-fabric-ca/${ARCH}-${CA_VERSION}/${CA_BINARY_FILE}
+  download "${CA_BINARY_FILE}" "https://github.com/hyperledger/fabric-ca/releases/download/v${CA_VERSION}/${CA_BINARY_FILE}"
   if [ $? -eq 22 ]; then
-     echo
-     echo "------> ${CA_TAG} fabric-ca-client binary is not available to download  (Available from 1.1.0-rc1) <----"
-     echo
-   fi
+    echo
+    echo "------> ${CA_TAG} fabric-ca-client binary is not available to download  (Available from 1.1.0-rc1) <----"
+    echo
+    exit
+  fi
 }
 
 binariesInstall
+

--- a/images/substra-ca-tools-debug/bootstrap-binaries.sh
+++ b/images/substra-ca-tools-debug/bootstrap-binaries.sh
@@ -23,73 +23,31 @@ export MARCH=$(uname -m)
 BINARY_FILE=hyperledger-fabric-${ARCH}-${VERSION}.tar.gz
 CA_BINARY_FILE=hyperledger-fabric-ca-${ARCH}-${CA_VERSION}.tar.gz
 
-# Incrementally downloads the .tar.gz file locally first, only decompressing it
-# after the download is complete. This is slower than binaryDownload() but
-# allows the download to be resumed.
-binaryIncrementalDownload() {
-      local BINARY_FILE=$1
-      local URL=$2
-      curl -f -s -C - ${URL} -o ${BINARY_FILE} || rc=$?
-      # Due to limitations in the current Nexus repo:
-      # curl returns 33 when there's a resume attempt with no more bytes to download
-      # curl returns 2 after finishing a resumed download
-      # with -f curl returns 22 on a 404
-      if [ "$rc" = 22 ]; then
-	  # looks like the requested file doesn't actually exist so stop here
-	  return 22
-      fi
-      if [ -z "$rc" ] || [ $rc -eq 33 ] || [ $rc -eq 2 ]; then
-          # The checksum validates that RC 33 or 2 are not real failures
-          echo "==> File downloaded. Verifying the md5sum..."
-          localMd5sum=$(md5sum ${BINARY_FILE} | awk '{print $1}')
-          remoteMd5sum=$(curl -s ${URL}.md5)
-          if [ "$localMd5sum" == "$remoteMd5sum" ]; then
-              echo "==> Extracting ${BINARY_FILE}..."
-              tar xzf ./${BINARY_FILE} --overwrite
-	      echo "==> Done."
-              rm -f ${BINARY_FILE} ${BINARY_FILE}.md5
-          else
-              echo "Download failed: the local md5sum is different from the remote md5sum. Please try again."
-              rm -f ${BINARY_FILE} ${BINARY_FILE}.md5
-              exit 1
-          fi
-      else
-          echo "Failure downloading binaries (curl RC=$rc). Please try again and the download will resume from where it stopped."
-          exit 1
-      fi
-}
-
-# This will attempt to download the .tar.gz all at once, but will trigger the
-# binaryIncrementalDownload() function upon a failure, allowing for resume
-# if there are network failures.
-binaryDownload() {
-      local BINARY_FILE=$1
-      local URL=$2
-      echo "===> Downloading: " ${URL}
-      # Check if a previous failure occurred and the file was partially downloaded
-      if [ -e ${BINARY_FILE} ]; then
-          echo "==> Partial binary file found. Resuming download..."
-          binaryIncrementalDownload ${BINARY_FILE} ${URL}
-      else
-          curl ${URL} | tar xz || rc=$?
-          if [ ! -z "$rc" ]; then
-              echo "==> There was an error downloading the binary file. Switching to incremental download."
-              echo "==> Downloading file..."
-              binaryIncrementalDownload ${BINARY_FILE} ${URL}
-	  else
-	      echo "==> Done."
-          fi
-      fi
+# This will download the .tar.gz
+download() {
+    local BINARY_FILE=$1
+    local URL=$2
+    echo "===> Downloading: " "${URL}"
+    wget "${URL}" || rc=$?
+    tar xvzf "${BINARY_FILE}" || rc=$?
+    rm "${BINARY_FILE}"
+    if [ -n "$rc" ]; then
+        echo "==> There was an error downloading the binary file."
+        return 22
+    else
+        echo "==> Done."
+    fi
 }
 
 binariesInstall() {
   echo "===> Downloading version ${CA_TAG} platform specific fabric-ca-client binary"
-  binaryDownload ${CA_BINARY_FILE} https://nexus.hyperledger.org/content/repositories/releases/org/hyperledger/fabric-ca/hyperledger-fabric-ca/${ARCH}-${CA_VERSION}/${CA_BINARY_FILE}
+  download "${CA_BINARY_FILE}" "https://github.com/hyperledger/fabric-ca/releases/download/v${CA_VERSION}/${CA_BINARY_FILE}"
   if [ $? -eq 22 ]; then
-     echo
-     echo "------> ${CA_TAG} fabric-ca-client binary is not available to download  (Available from 1.1.0-rc1) <----"
-     echo
-   fi
+    echo
+    echo "------> ${CA_TAG} fabric-ca-client binary is not available to download  (Available from 1.1.0-rc1) <----"
+    echo
+    exit
+  fi
 }
 
 binariesInstall

--- a/images/substra-ca-tools/bootstrap-binaries.sh
+++ b/images/substra-ca-tools/bootstrap-binaries.sh
@@ -23,73 +23,31 @@ export MARCH=$(uname -m)
 BINARY_FILE=hyperledger-fabric-${ARCH}-${VERSION}.tar.gz
 CA_BINARY_FILE=hyperledger-fabric-ca-${ARCH}-${CA_VERSION}.tar.gz
 
-# Incrementally downloads the .tar.gz file locally first, only decompressing it
-# after the download is complete. This is slower than binaryDownload() but
-# allows the download to be resumed.
-binaryIncrementalDownload() {
-      local BINARY_FILE=$1
-      local URL=$2
-      curl -f -s -C - ${URL} -o ${BINARY_FILE} || rc=$?
-      # Due to limitations in the current Nexus repo:
-      # curl returns 33 when there's a resume attempt with no more bytes to download
-      # curl returns 2 after finishing a resumed download
-      # with -f curl returns 22 on a 404
-      if [ "$rc" = 22 ]; then
-	  # looks like the requested file doesn't actually exist so stop here
-	  return 22
-      fi
-      if [ -z "$rc" ] || [ $rc -eq 33 ] || [ $rc -eq 2 ]; then
-          # The checksum validates that RC 33 or 2 are not real failures
-          echo "==> File downloaded. Verifying the md5sum..."
-          localMd5sum=$(md5sum ${BINARY_FILE} | awk '{print $1}')
-          remoteMd5sum=$(curl -s ${URL}.md5)
-          if [ "$localMd5sum" == "$remoteMd5sum" ]; then
-              echo "==> Extracting ${BINARY_FILE}..."
-              tar xzf ./${BINARY_FILE} --overwrite
-	      echo "==> Done."
-              rm -f ${BINARY_FILE} ${BINARY_FILE}.md5
-          else
-              echo "Download failed: the local md5sum is different from the remote md5sum. Please try again."
-              rm -f ${BINARY_FILE} ${BINARY_FILE}.md5
-              exit 1
-          fi
-      else
-          echo "Failure downloading binaries (curl RC=$rc). Please try again and the download will resume from where it stopped."
-          exit 1
-      fi
-}
-
-# This will attempt to download the .tar.gz all at once, but will trigger the
-# binaryIncrementalDownload() function upon a failure, allowing for resume
-# if there are network failures.
-binaryDownload() {
-      local BINARY_FILE=$1
-      local URL=$2
-      echo "===> Downloading: " ${URL}
-      # Check if a previous failure occurred and the file was partially downloaded
-      if [ -e ${BINARY_FILE} ]; then
-          echo "==> Partial binary file found. Resuming download..."
-          binaryIncrementalDownload ${BINARY_FILE} ${URL}
-      else
-          curl ${URL} | tar xz || rc=$?
-          if [ ! -z "$rc" ]; then
-              echo "==> There was an error downloading the binary file. Switching to incremental download."
-              echo "==> Downloading file..."
-              binaryIncrementalDownload ${BINARY_FILE} ${URL}
-	  else
-	      echo "==> Done."
-          fi
-      fi
+# This will download the .tar.gz
+download() {
+    local BINARY_FILE=$1
+    local URL=$2
+    echo "===> Downloading: " "${URL}"
+    wget "${URL}" || rc=$?
+    tar xvzf "${BINARY_FILE}" || rc=$?
+    rm "${BINARY_FILE}"
+    if [ -n "$rc" ]; then
+        echo "==> There was an error downloading the binary file."
+        return 22
+    else
+        echo "==> Done."
+    fi
 }
 
 binariesInstall() {
   echo "===> Downloading version ${CA_TAG} platform specific fabric-ca-client binary"
-  binaryDownload ${CA_BINARY_FILE} https://nexus.hyperledger.org/content/repositories/releases/org/hyperledger/fabric-ca/hyperledger-fabric-ca/${ARCH}-${CA_VERSION}/${CA_BINARY_FILE}
+  download "${CA_BINARY_FILE}" "https://github.com/hyperledger/fabric-ca/releases/download/v${CA_VERSION}/${CA_BINARY_FILE}"
   if [ $? -eq 22 ]; then
-     echo
-     echo "------> ${CA_TAG} fabric-ca-client binary is not available to download  (Available from 1.1.0-rc1) <----"
-     echo
-   fi
+    echo
+    echo "------> ${CA_TAG} fabric-ca-client binary is not available to download  (Available from 1.1.0-rc1) <----"
+    echo
+    exit
+  fi
 }
 
 binariesInstall


### PR DESCRIPTION
Issue : https://github.com/SubstraFoundation/substra/issues/111
Nexus seems to be unavailable and binaries are now download from github 
Based on https://github.com/hyperledger/fabric/blob/master/scripts/bootstrap.sh