### PR TITLE
Use substra.Client new login method

### DIFF
--- a/python-scripts/watch_compute_plan.py
+++ b/python-scripts/watch_compute_plan.py
@@ -21,8 +21,8 @@ import substra
 
 USER, PASSWORD = ('substra', 'p@$swr0d44')
 client = substra.Client()
-client.add_profile('owkin', USER, PASSWORD, 'http://substra-backend.owkin.xyz:8000')
-client.login()
+client.add_profile('owkin', 'http://substra-backend.owkin.xyz:8000')
+client.login(USER, PASSWORD)
 
 
 def load_tuple_keys(path):


### PR DESCRIPTION
Companion PR to https://github.com/SubstraFoundation/substra/pull/138

I updated the script because it made use of the substra client but upon closer look it seems this is outdated code altogether (hardcodes the docker-compose config, only watches for traintuples and testtuples, etc.)

Maybe I should remove it altogether?