### PR TITLE
Update travis file to build only the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: minimal
 
+branches:
+  only:
+    - master
+
 addons:
   snaps:
     - name: helm

--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 1.0.0-alpha.11
+version: 1.0.0-alpha.12
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:


### PR DESCRIPTION
This will prevent from overriding the hlf-k8s chart with an unstable version.