### PR TITLE
Add ConfigMap option for chaincode

### DIFF
--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 1.1.0
+version: 1.1.1
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -35,7 +35,7 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `chaincodes[].src` | The URL to a chaincode archive (.tar.gz) | (undefined) |
 | `chaincodes[].hostPath` | A host path containing the chaincode source code | (undefined) |
 | `chaincodes[].configMap.name` | The name of a ConfigMap containing the chaincode source code (tar.gz) | (undefined) |
-| `chaincodes[].configMap.fileName` | The name of the archive within the source code | (undefined) |
+| `chaincodes[].configMap.fileName` | The name of the archive within the ConfigMap | (undefined) |
 | `appChannel.name` | The name of the application channel | `mychannel` |
 | `appChannel.organizations` | The organizations to add to the application channel. See [Add an organization to the application channel](#add-an-organization-to-the-application-channel). | `[]` |
 | `appChannel.proposalOrganizations` | The organizations to fetch signed application channel update proposals from. | `[]` |

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -30,6 +30,12 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `peer.persistence.size` | Size of data volume | (undefined) |
 | `peer.persistence.storageClass` | Storage class of backing PVC | (undefined) |
 | `chaincodes` | The chaincodes to install on the Peer. See [Install a chaincode](#install-a-chaincode). | `[]` |
+| `chaincodes[].name` | The name of the chaincode | (undefined) |
+| `chaincodes[].version` | The chaincode version | (undefined) |
+| `chaincodes[].src` | The URL to a chaincode archive (.tar.gz) | (undefined) |
+| `chaincodes[].hostPath` | A host path containing the chaincode source code | (undefined) |
+| `chaincodes[].configMap.name` | The name of a ConfigMap containing the chaincode source code (tar.gz) | (undefined) |
+| `chaincodes[].configMap.fileName` | The name of the archive within the source code | (undefined) |
 | `appChannel.name` | The name of the application channel | `mychannel` |
 | `appChannel.organizations` | The organizations to add to the application channel. See [Add an organization to the application channel](#add-an-organization-to-the-application-channel). | `[]` |
 | `appChannel.proposalOrganizations` | The organizations to fetch signed application channel update proposals from. | `[]` |
@@ -108,6 +114,8 @@ chaincodes:
     # Chaincode source code archive URL
     src: https://github.com/SubstraFoundation/substra-chaincode/archive/0.0.2.tar.gz
 ```
+
+You can also provide the chaincode source code using a ConfigMap or a host path (see: [Configuration](#Configuration))
 
 ### Add an organization to the system channel
 

--- a/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
@@ -61,15 +61,17 @@ spec:
                   rm -rf /opt/gopath/src/chaincode
 
                   ## Fetch chaincode src
-                  if [[ {{ .src | quote }} == http* ]];
-                  then
-                    curl -L {{ .src }} -o chaincode.tar.gz
-                    tar -C substra-chaincode -xzf chaincode.tar.gz --strip-components=1
-                    mv substra-chaincode/chaincode /opt/gopath/src/chaincode
-                  else
-                    mkdir -p /opt/gopath/src/chaincode
-                    cp -R {{ .src }}/chaincode/* /opt/gopath/src/chaincode
-                  fi
+            {{- if .configMap }}
+                  tar -C substra-chaincode -xzf /chaincode/{{ .configMap.fileName }} --strip-components=1
+                  mv substra-chaincode/chaincode /opt/gopath/src/chaincode
+            {{- else if .hostPath }}
+                  mkdir -p /opt/gopath/src/chaincode
+                  cp -LR /chaincode/* /opt/gopath/src/chaincode
+            {{- else }}
+                  curl -L {{ .src }} -o chaincode.tar.gz
+                  tar -C substra-chaincode -xzf chaincode.tar.gz --strip-components=1
+                  mv substra-chaincode/chaincode /opt/gopath/src/chaincode
+            {{- end }}
 
                   ## Install chaincode
                   peer chaincode install -n {{ .name }} -v {{ .version }} -p chaincode
@@ -128,9 +130,10 @@ spec:
               name: private-ca
               subPath: {{ $.Values.privateCa.configMap.fileName }}
             {{- end }}
-            {{- if ne "http" (regexFind "^http" .src) }}
-            - mountPath: {{ .src }}
-              name: chaincode-local-src
+            {{- if or .hostPath .configMap }}
+            - mountPath: /chaincode
+              name: chaincode
+              readOnly: true
             {{- end }}
       volumes:
       - name: fabric-config
@@ -173,10 +176,15 @@ spec:
         configMap:
           name: {{ $.Values.privateCa.configMap.name }}
       {{- end }}
-      {{- if ne "http" (regexFind "^http" .src) }}
-      - name: chaincode-local-src
+      {{- if .hostPath }}
+      - name: chaincode
         hostPath:
-          path: {{ .src }}
+          path: {{ .hostPath }}
+      {{- end }}
+      {{- if .configMap }}
+      - name: chaincode
+        configMap:
+          name: {{ .configMap.name }}
       {{- end }}
     {{- with $.Values.nodeSelector }}
       nodeSelector:

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -227,13 +227,15 @@ chaincodes: []
   # -
   #   name: mycc
   #   version: "1.0"
-  ##  The chaincode source code. It can be either:
-  ##  - The absolute path to the source code on your local machine. (Note for minikube users:
-  ##    this path must be mounted in minikube, see https://stackoverflow.com/a/53251666/1370722)
-  ##  - The URL of a tar gzipped archive of the chaincode source code, accessible from the
-  ##    internet. /!\ The archive name cannot contain the `/` character.
-  #   src: /home/johndoe/code/susbtra-chaincode
+  ## The chaincode source code can be provided one of 3 ways:
+  ## 1. Archive URL (Note: the archive name cannot contain the `/` character)
   #   src: https://github.com/SubstraFoundation/substra-chaincode/archive/0.0.2.tar.gz
+  ## 2. A host path
+  #   hostPath: /home/johndoe/code/susbtra-chaincode
+  ## 3. A ConfigMap
+  #   configMap:
+  #     name: hlf-chaincode
+  #     fileName: chaincode.tar.gz
 
 users:
   admin:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -81,8 +81,6 @@ deploy:
           chaincodes[0].instantiate: true
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
-          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
-          #       This path must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
           appChannel.name: mychannel
           appChannel.organizations[0].org: MyOrg1
@@ -132,8 +130,6 @@ deploy:
           peer.peer.mspID: MyOrg2MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
-          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
-          #       This path folder must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
           appChannel.name: mychannel
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member')

--- a/tools/skaffold-3orgs.yaml
+++ b/tools/skaffold-3orgs.yaml
@@ -89,8 +89,6 @@ deploy:
           chaincodes[0].instantiate: true
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
-          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
-          #       This path must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
           appChannel.name: mychannel
           appChannel.organizations[0].org: MyOrg1
@@ -139,8 +137,6 @@ deploy:
           peer.peer.mspID: MyOrg2MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
-          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
-          #       This path folder must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
           appChannel.name: mychannel
           appChannel.organizations[0].org: MyOrg1
@@ -189,8 +185,6 @@ deploy:
           peer.peer.mspID: MyOrg3MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
-          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
-          #       This path folder must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
           appChannel.name: mychannel
           appChannel.organizations[0].org: MyOrg1

--- a/tools/skaffold-4orgs.yaml
+++ b/tools/skaffold-4orgs.yaml
@@ -91,8 +91,6 @@ deploy:
           chaincodes[0].instantiate: true
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
-          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
-          #       This path must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
           appChannel.name: mychannel
           appChannel.organizations[0].org: MyOrg1
@@ -145,8 +143,6 @@ deploy:
           peer.peer.mspID: MyOrg2MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
-          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
-          #       This path folder must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
           appChannel.name: mychannel
           appChannel.organizations[0].org: MyOrg1
@@ -199,8 +195,6 @@ deploy:
           peer.peer.mspID: MyOrg3MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
-          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
-          #       This path folder must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
           appChannel.name: mychannel
           appChannel.organizations[0].org: MyOrg1
@@ -252,8 +246,6 @@ deploy:
           peer.peer.mspID: MyOrg4MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
-          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
-          #       This path folder must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
           appChannel.name: mychannel
           appChannel.organizations[0].org: MyOrg1


### PR DESCRIPTION
This removes the need for internet in the chaincode operator

Testing:

```
curl -L https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz -o chaincode.tar.gz
kubectl create configmap hlf-chaincode --from-file=chaincode.tar.gz -n org-1
```

Then in skaffold.yaml (peer 1)

```
chaincodes[0].configMap.name: hlf-chaincode
chaincodes[0].configMap.fileName: chaincode.tar.gz
```