### PR TITLE
Disable hooks and toolbox by default + remove ClusterRole

### DIFF
--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 1.1.1
+version: 1.2.1
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -51,7 +51,7 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `applicationChannelOperator.ingress`<br>&nbsp;&nbsp;&nbsp;&nbsp;`.annotations` | Application channel operator ingress annotations | (undefined) |
 | `applicationChannelOperator.ingress`<br>&nbsp;&nbsp;&nbsp;&nbsp;`.tls` | Application channel operator ingress TLS configuration | (undefined) |
 | `applicationChannelOperator.ingress`<br>&nbsp;&nbsp;&nbsp;&nbsp;`.hosts` | Application channel operator ingress hosts | (undefined) |
-| `hooks.uninstallChaincode.enabled` | If true, the chaincode will be automatically uninstalled when the chart is uninstalled | `false` |
+| `hooks.uninstallChaincode.enabled` | If true, the chaincode will be automatically uninstalled when the chart is uninstalled | `true` |
 | **Orderer** |  |  |
 | `orderer.enabled` | If true, a HLF Orderer will be installed | `false` |
 | `orderer.host` | The hostname for the Orderer | `orderer-hostname` |
@@ -94,7 +94,7 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `privateCa.enabled` | if true, use a private CA | `false` |
 | `privateCa.configMap.name` | The name of the ConfigMap containing the private CA certificate | `private-ca` |
 | `privateCa.configMap.fileName` | The CA certificate filename within the ConfigMap | `private-ca.crt` |
-| `hooks.deleteSecrets.enabled` | If true, the secrets created by the chart will be automatically deleted when the chart is uninstalled | `false` |
+| `hooks.deleteSecrets.enabled` | If true, the secrets created by the chart will be automatically deleted when the chart is uninstalled | `true` |
 | `toolbox.enabled` | If true, a "toolbox" pod will be created with pre-installed utilities and certificates | `false` |
 
 

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `applicationChannelOperator.ingress`<br>&nbsp;&nbsp;&nbsp;&nbsp;`.annotations` | Application channel operator ingress annotations | (undefined) |
 | `applicationChannelOperator.ingress`<br>&nbsp;&nbsp;&nbsp;&nbsp;`.tls` | Application channel operator ingress TLS configuration | (undefined) |
 | `applicationChannelOperator.ingress`<br>&nbsp;&nbsp;&nbsp;&nbsp;`.hosts` | Application channel operator ingress hosts | (undefined) |
+| `hooks.uninstallChaincode.enabled` | If true, the chaincode will be automatically uninstalled when the chart is uninstalled | `false` |
 | **Orderer** |  |  |
 | `orderer.enabled` | If true, a HLF Orderer will be installed | `false` |
 | `orderer.host` | The hostname for the Orderer | `orderer-hostname` |
@@ -93,6 +94,8 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `privateCa.enabled` | if true, use a private CA | `false` |
 | `privateCa.configMap.name` | The name of the ConfigMap containing the private CA certificate | `private-ca` |
 | `privateCa.configMap.fileName` | The CA certificate filename within the ConfigMap | `private-ca.crt` |
+| `hooks.deleteSecrets.enabled` | If true, the secrets created by the chart will be automatically deleted when the chart is uninstalled | `false` |
+| `toolbox.enabled` | If true, a "toolbox" pod will be created with pre-installed utilities and certificates | `false` |
 
 
 ## Usage

--- a/charts/hlf-k8s/templates/deployment-toolbox.yaml
+++ b/charts/hlf-k8s/templates/deployment-toolbox.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if .Values.toolbox.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -136,3 +137,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- end }}

--- a/charts/hlf-k8s/templates/job-hook-delete-secrets.yaml
+++ b/charts/hlf-k8s/templates/job-hook-delete-secrets.yaml
@@ -15,12 +15,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "substra.fullname" . }}-hook-cleanup
+  name: {{ template "substra.fullname" . }}-hook-delete-secrets
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/name: {{ template "substra.name" . }}-hook-cleanup
+    app.kubernetes.io/name: {{ template "substra.name" . }}-hook-delete-secrets
     app.kubernetes.io/part-of: {{ template "substra.name" . }}
   annotations:
     "helm.sh/hook": post-delete

--- a/charts/hlf-k8s/templates/job-hook-delete-secrets.yaml
+++ b/charts/hlf-k8s/templates/job-hook-delete-secrets.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if .Values.hooks.deleteSecrets.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -70,3 +71,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- end }}

--- a/charts/hlf-k8s/templates/job-hook-uninstall-chaincode.yaml
+++ b/charts/hlf-k8s/templates/job-hook-uninstall-chaincode.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.peer.enabled }}
+{{- if and (.Values.peer.enabled) (.Values.hooks.uninstallChaincode.enabled) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/hlf-k8s/templates/job-hook-uninstall-chaincode.yaml
+++ b/charts/hlf-k8s/templates/job-hook-uninstall-chaincode.yaml
@@ -16,12 +16,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "substra.fullname" . }}-hook-desinstall-chaincode
+  name: {{ template "substra.fullname" . }}-hook-uninstall-chaincode
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/name: {{ template "substra.name" . }}-hook-desinstall-chaincode
+    app.kubernetes.io/name: {{ template "substra.name" . }}-hook-uninstall-chaincode
     app.kubernetes.io/part-of: {{ template "substra.name" . }}
   annotations:
     "helm.sh/hook": pre-delete

--- a/charts/hlf-k8s/templates/rbac.yaml
+++ b/charts/hlf-k8s/templates/rbac.yaml
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/name: {{ template "substra.name" . }}
     app.kubernetes.io/part-of: {{ template "substra.name" . }}
 ---
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "substra.fullname" . }}
@@ -36,16 +36,17 @@ metadata:
     app.kubernetes.io/part-of: {{ template "substra.name" . }}
 rules:
 - apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "watch", "list", "create", "delete"]
-- apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "watch", "list", "create", "delete"]
-- apiGroups: [""]
-  resources: ["pods/exec"]
-  verbs: ["create"]
+  verbs:
+    - get
+    - watch
+    - list
+    - create
+    {{- if .Values.hooks.deleteSecrets.enabled }}
+    - delete
+    {{- end }}
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "substra.fullname" . }}
@@ -60,6 +61,6 @@ subjects:
   name: {{ template "substra.fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: {{ template "substra.fullname" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -299,4 +299,4 @@ hooks:
     enabled: false
 
 toolbox:
-  enable: false
+  enabled: false

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -294,9 +294,9 @@ enrollments:
 
 hooks:
   deleteSecrets:
-    enabled: false
+    enabled: true
   uninstallChaincode:
-    enabled: false
+    enabled: true
 
 toolbox:
   enabled: false

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -291,3 +291,12 @@ enrollments:
   # - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
   # - { name: user, secret: pwd, options: "--id.type peer"}
   csrHost: service-hostname
+
+hooks:
+  deleteSecrets:
+    enabled: false
+  uninstallChaincode:
+    enabled: false
+
+toolbox:
+  enable: false

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -60,7 +60,6 @@ deploy:
           enrollments.creds[1].secret: pwd
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer.orderer
-          hooks.deleteSecrets.enabled: true
           toolbox.enabled: true
 
       - name: network-org-1-peer-1
@@ -111,8 +110,6 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1.org-1
-          hooks.deleteSecrets.enabled: true
-          hooks.uninstallChaincode.enabled: true
           toolbox.enabled: true
 
 
@@ -149,7 +146,5 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1.org-2
-          hooks.deleteSecrets.enabled: true
-          hooks.uninstallChaincode.enabled: true
           toolbox.enabled: true
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -60,6 +60,8 @@ deploy:
           enrollments.creds[1].secret: pwd
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer.orderer
+          hooks.deleteSecrets.enabled: true
+          toolbox.enabled: true
 
       - name: network-org-1-peer-1
         chartPath: charts/hlf-k8s
@@ -109,6 +111,9 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1.org-1
+          hooks.deleteSecrets.enabled: true
+          hooks.uninstallChaincode.enabled: true
+          toolbox.enabled: true
 
 
       - name: network-org-2-peer-1
@@ -144,3 +149,7 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1.org-2
+          hooks.deleteSecrets.enabled: true
+          hooks.uninstallChaincode.enabled: true
+          toolbox.enabled: true
+

--- a/tools/skaffold-3orgs.yaml
+++ b/tools/skaffold-3orgs.yaml
@@ -68,7 +68,6 @@ deploy:
           enrollments.creds[1].secret: pwd
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer.orderer
-          hooks.deleteSecrets.enabled: true
           toolbox.enabled: true
 
       - name: network-org-1-peer-1
@@ -118,8 +117,6 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1.org-1
-          hooks.deleteSecrets.enabled: true
-          hooks.uninstallChaincode.enabled: true
           toolbox.enabled: true
 
 
@@ -169,8 +166,6 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1.org-2
-          hooks.deleteSecrets.enabled: true
-          hooks.uninstallChaincode.enabled: true
           toolbox.enabled: true
 
 
@@ -219,6 +214,4 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-3-peer-1.org-3
-          hooks.deleteSecrets.enabled: true
-          hooks.uninstallChaincode.enabled: true
           toolbox.enabled: true

--- a/tools/skaffold-3orgs.yaml
+++ b/tools/skaffold-3orgs.yaml
@@ -68,6 +68,8 @@ deploy:
           enrollments.creds[1].secret: pwd
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer.orderer
+          hooks.deleteSecrets.enabled: true
+          toolbox.enabled: true
 
       - name: network-org-1-peer-1
         chartPath: charts/hlf-k8s
@@ -116,6 +118,9 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1.org-1
+          hooks.deleteSecrets.enabled: true
+          hooks.uninstallChaincode.enabled: true
+          toolbox.enabled: true
 
 
       - name: network-org-2-peer-1
@@ -164,6 +169,9 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1.org-2
+          hooks.deleteSecrets.enabled: true
+          hooks.uninstallChaincode.enabled: true
+          toolbox.enabled: true
 
 
       - name: network-org-3-peer-1
@@ -211,3 +219,6 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-3-peer-1.org-3
+          hooks.deleteSecrets.enabled: true
+          hooks.uninstallChaincode.enabled: true
+          toolbox.enabled: true

--- a/tools/skaffold-4orgs-policy-any.yaml
+++ b/tools/skaffold-4orgs-policy-any.yaml
@@ -70,7 +70,6 @@ deploy:
           enrollments.creds[1].secret: pwd
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer.orderer
-          hooks.deleteSecrets.enabled: true
           toolbox.enabled: true
 
       - name: network-org-1-peer-1
@@ -126,8 +125,6 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1.org-1
-          hooks.deleteSecrets.enabled: true
-          hooks.uninstallChaincode.enabled: true
           toolbox.enabled: true
 
 
@@ -164,8 +161,6 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1.org-2
-          hooks.deleteSecrets.enabled: true
-          hooks.uninstallChaincode.enabled: true
           toolbox.enabled: true
 
 
@@ -203,8 +198,6 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-3-peer-1.org-3
-          hooks.deleteSecrets.enabled: true
-          hooks.uninstallChaincode.enabled: true
           toolbox.enabled: true
 
       - name: network-org-4-peer-1
@@ -241,6 +234,4 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-4-peer-1.org-4
-          hooks.deleteSecrets.enabled: true
-          hooks.uninstallChaincode.enabled: true
           toolbox.enabled: true

--- a/tools/skaffold-4orgs-policy-any.yaml
+++ b/tools/skaffold-4orgs-policy-any.yaml
@@ -70,6 +70,8 @@ deploy:
           enrollments.creds[1].secret: pwd
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer.orderer
+          hooks.deleteSecrets.enabled: true
+          toolbox.enabled: true
 
       - name: network-org-1-peer-1
         chartPath: charts/hlf-k8s
@@ -91,8 +93,6 @@ deploy:
           chaincodes[0].instantiate: true
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
-          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
-          #       This path must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
           appChannel.name: mychannel
           appChannel.organizations[0].org: MyOrg1
@@ -126,6 +126,9 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1.org-1
+          hooks.deleteSecrets.enabled: true
+          hooks.uninstallChaincode.enabled: true
+          toolbox.enabled: true
 
 
       - name: network-org-2-peer-1
@@ -147,8 +150,6 @@ deploy:
           peer.peer.mspID: MyOrg2MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
-          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
-          #       This path folder must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
           appChannel.name: mychannel
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member'\,'MyOrg3MSP.member'\,'MyOrg4MSP.member')
@@ -163,6 +164,9 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1.org-2
+          hooks.deleteSecrets.enabled: true
+          hooks.uninstallChaincode.enabled: true
+          toolbox.enabled: true
 
 
       - name: network-org-3-peer-1
@@ -184,8 +188,6 @@ deploy:
           peer.peer.mspID: MyOrg3MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
-          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
-          #       This path folder must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
           appChannel.name: mychannel
           # appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member')
@@ -201,6 +203,9 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-3-peer-1.org-3
+          hooks.deleteSecrets.enabled: true
+          hooks.uninstallChaincode.enabled: true
+          toolbox.enabled: true
 
       - name: network-org-4-peer-1
         chartPath: charts/hlf-k8s
@@ -221,8 +226,6 @@ deploy:
           peer.peer.mspID: MyOrg4MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
-          # Note: Instead of an URL, you can use an absolute path, e.g. /home/johndoe/code/substra-chaincode
-          #       This path folder must be accessible to kubernetes. See README for details.
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
           appChannel.name: mychannel
           # appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member')
@@ -238,3 +241,6 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-4-peer-1.org-4
+          hooks.deleteSecrets.enabled: true
+          hooks.uninstallChaincode.enabled: true
+          toolbox.enabled: true

--- a/tools/skaffold-4orgs.yaml
+++ b/tools/skaffold-4orgs.yaml
@@ -70,6 +70,8 @@ deploy:
           enrollments.creds[1].secret: pwd
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer.orderer
+          hooks.deleteSecrets.enabled: true
+          toolbox.enabled: true
 
       - name: network-org-1-peer-1
         chartPath: charts/hlf-k8s
@@ -122,6 +124,9 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1.org-1
+          hooks.deleteSecrets.enabled: true
+          hooks.uninstallChaincode.enabled: true
+          toolbox.enabled: true
 
 
       - name: network-org-2-peer-1
@@ -174,6 +179,9 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1.org-2
+          hooks.deleteSecrets.enabled: true
+          hooks.uninstallChaincode.enabled: true
+          toolbox.enabled: true
 
 
       - name: network-org-3-peer-1
@@ -226,6 +234,9 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-3-peer-1.org-3
+          hooks.deleteSecrets.enabled: true
+          hooks.uninstallChaincode.enabled: true
+          toolbox.enabled: true
 
       - name: network-org-4-peer-1
         chartPath: charts/hlf-k8s
@@ -277,3 +288,6 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-4-peer-1.org-4
+          hooks.deleteSecrets.enabled: true
+          hooks.uninstallChaincode.enabled: true
+          toolbox.enabled: true

--- a/tools/skaffold-4orgs.yaml
+++ b/tools/skaffold-4orgs.yaml
@@ -70,7 +70,6 @@ deploy:
           enrollments.creds[1].secret: pwd
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer.orderer
-          hooks.deleteSecrets.enabled: true
           toolbox.enabled: true
 
       - name: network-org-1-peer-1
@@ -124,8 +123,6 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1.org-1
-          hooks.deleteSecrets.enabled: true
-          hooks.uninstallChaincode.enabled: true
           toolbox.enabled: true
 
 
@@ -179,8 +176,6 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1.org-2
-          hooks.deleteSecrets.enabled: true
-          hooks.uninstallChaincode.enabled: true
           toolbox.enabled: true
 
 
@@ -234,8 +229,6 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-3-peer-1.org-3
-          hooks.deleteSecrets.enabled: true
-          hooks.uninstallChaincode.enabled: true
           toolbox.enabled: true
 
       - name: network-org-4-peer-1
@@ -288,6 +281,4 @@ deploy:
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-4-peer-1.org-4
-          hooks.deleteSecrets.enabled: true
-          hooks.uninstallChaincode.enabled: true
           toolbox.enabled: true


### PR DESCRIPTION
A bunch of changes:

- Remove unnecessary rbac capabilities ("resources")
- Change from using a `ClusterRole` to using a `Role`﻿
- rename hook files
- make hooks disabled by default (uninstall chaincode + delete secrets), but enable them in skaffold
- make toolbox disabled by default, but enable it in skaffold

