### PR TITLE
Remove all aliases

### DIFF
--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 1.2.2
+version: 1.3.0
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -17,18 +17,18 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | Parameter                          | Description                                     | Default                                                    |
 | ---------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
 | **Peer** |  |  |
-| `peer.enabled` | If true, a HLF Peer will be installed | `true` |
-| `peer.peer.mspID` | ID of MSP the Peer belongs to | `Org1MSP` |
-| `peer.peer.gossip.externalEndpoint` | HLF peer gossip external endpoint | `""` |
-| `peer.host` | The Peers's host | `peer-hostname` |
-| `peer.port` | The Peers's port | `7051` |
-| `peer.ingress.enabled` | If true, Ingress will be created for the Peer | `false` |
-| `peer.ingress.annotations` | Peer ingress annotations | (undefined) |
-| `peer.ingress.tls` | Peer ingress TLS configuration | (undefined) |
-| `peer.ingress.hosts` | Peer ingress hosts | (undefined) |
-| `peer.persistence.enabled` | If true, enable persistence for the Peer | `false` |
-| `peer.persistence.size` | Size of data volume | (undefined) |
-| `peer.persistence.storageClass` | Storage class of backing PVC | (undefined) |
+| `hlf-peer.enabled` | If true, a HLF Peer will be installed | `true` |
+| `hlf-peer.peer.mspID` | ID of MSP the Peer belongs to | `Org1MSP` |
+| `hlf-peer.peer.gossip.externalEndpoint` | HLF peer gossip external endpoint | `""` |
+| `hlf-peer.host` | The Peers's host | `peer-hostname` |
+| `hlf-peer.port` | The Peers's port | `7051` |
+| `hlf-peer.ingress.enabled` | If true, Ingress will be created for the Peer | `false` |
+| `hlf-peer.ingress.annotations` | Peer ingress annotations | (undefined) |
+| `hlf-peer.ingress.tls` | Peer ingress TLS configuration | (undefined) |
+| `hlf-peer.ingress.hosts` | Peer ingress hosts | (undefined) |
+| `hlf-peer.persistence.enabled` | If true, enable persistence for the Peer | `false` |
+| `hlf-peer.persistence.size` | Size of data volume | (undefined) |
+| `hlf-peer.persistence.storageClass` | Storage class of backing PVC | (undefined) |
 | `chaincodes` | The chaincodes to install on the Peer. See [Install a chaincode](#install-a-chaincode). | `[]` |
 | `chaincodes[].name` | The name of the chaincode | (undefined) |
 | `chaincodes[].version` | The chaincode version | (undefined) |
@@ -53,17 +53,17 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `applicationChannelOperator.ingress`<br>&nbsp;&nbsp;&nbsp;&nbsp;`.hosts` | Application channel operator ingress hosts | (undefined) |
 | `hooks.uninstallChaincode.enabled` | If true, the chaincode will be automatically uninstalled when the chart is uninstalled | `true` |
 | **Orderer** |  |  |
-| `orderer.enabled` | If true, a HLF Orderer will be installed | `false` |
-| `orderer.host` | The hostname for the Orderer | `orderer-hostname` |
-| `orderer.ord.mspID` | ID of MSP the Orderer belongs to | `MyOrdererMSP` |
-| `orderer.monitor.enabled` | If true, create a monitor pod (see [Monitor pod](#monitor-pod)) | `false` |
-| `orderer.ingress.enabled` | If true, Ingress will be created for the Orderer | (undefined) |
-| `orderer.ingress.annotations` | Orderer ingress annotations | (undefined) |
-| `orderer.ingress.tls` | Orderer ingress TLS configuration | (undefined) |
-| `orderer.ingress.hosts` | Orderer ingress hosts | (undefined) |
-| `orderer.persistence.enabled` | If true, enable persistence for the Orderer | `false` |
-| `orderer.persistence.size` | Size of data volume | (undefined) |
-| `orderer.persistence.storageClass` | Storage class of backing PVC | (undefined) |
+| `hlf-ord.enabled` | If true, a HLF Orderer will be installed | `false` |
+| `hlf-ord.host` | The hostname for the Orderer | `orderer-hostname` |
+| `hlf-ord.ord.mspID` | ID of MSP the Orderer belongs to | `MyOrdererMSP` |
+| `hlf-ord.monitor.enabled` | If true, create a monitor pod (see [Monitor pod](#monitor-pod)) | `false` |
+| `hlf-ord.ingress.enabled` | If true, Ingress will be created for the Orderer | (undefined) |
+| `hlf-ord.ingress.annotations` | Orderer ingress annotations | (undefined) |
+| `hlf-ord.ingress.tls` | Orderer ingress TLS configuration | (undefined) |
+| `hlf-ord.ingress.hosts` | Orderer ingress hosts | (undefined) |
+| `hlf-ord.persistence.enabled` | If true, enable persistence for the Orderer | `false` |
+| `hlf-ord.persistence.size` | Size of data volume | (undefined) |
+| `hlf-ord.persistence.storageClass` | Storage class of backing PVC | (undefined) |
 | `systemChannel.name` | The name of the system channel | `systemchannel` |
 | `systemChannel.organizations` | The organizations to add to the system channel. See [Add an organization to the system channel](#add-an-organization-to-the-system-channel). | `[]` |
 | **Common / Other** |  |  |
@@ -75,20 +75,20 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `affinity` | Affinity settings for pod assignment | `{}` |
 | `organization.id` | The organization id | `MyOrganizationMSP` |
 | `organization.name` | The organization name | `MyOrganization` |
-| `orderer.host` | The Orderer's host | `orderer-hostname` |
-| `orderer.port` | The Orderer's port | `7050` |
+| `hlf-ord.host` | The Orderer's host | `orderer-hostname` |
+| `hlf-ord.port` | The Orderer's port | `7050` |
 | `enrollments.creds` | The users to enroll with the CA | `[]` |
 | `enrollments.csrHost` | The value to pass to `--csr.hosts` when enrolling users to the CA | `service-hostname` |
-| `ca.caName` | Name of CA | `rca` |
-| `ca.scheme` | CA scheme | `http` |
-| `ca.host` | CA host | `ca-hostname` |
-| `ca.port` | CA port | `7054` |
-| `ca.orderer.scheme` | Orderer's CA scheme | `http` |
-| `ca.orderer.host` | Orderer's CA host | `orderer-ca-hostname` |
-| `ca.orderer.port` | Orderer's CA port | `7054` |
-| `ca.persistence.enabled` | If true, enable persistence for the CA | `false` |
-| `ca.persistence.size` | Size of data volume | (undefined) |
-| `ca.persistence.storageClass` | Storage class of backing PVC | (undefined) |
+| `hlf-ca.caName` | Name of CA | `rca` |
+| `hlf-ca.scheme` | CA scheme | `http` |
+| `hlf-ca.host` | CA host | `ca-hostname` |
+| `hlf-ca.port` | CA port | `7054` |
+| `hlf-ca.orderer.scheme` | Orderer's CA scheme | `http` |
+| `hlf-ca.orderer.host` | Orderer's CA host | `orderer-ca-hostname` |
+| `hlf-ca.orderer.port` | Orderer's CA port | `7054` |
+| `hlf-ca.persistence.enabled` | If true, enable persistence for the CA | `false` |
+| `hlf-ca.persistence.size` | Size of data volume | (undefined) |
+| `hlf-ca.persistence.storageClass` | Storage class of backing PVC | (undefined) |
 | `nginx-ingress.enabled` | If true, an nginx Ingress controller will be created | `false` |
 | `nginx-ingress.controller.nginx-ingress.extraArgs` | Additional controller arguments | `enable-ssl-passthrough: ""` |
 | `privateCa.enabled` | if true, use a private CA | `false` |
@@ -127,7 +127,7 @@ Adding an organization to the system channel allows it to adminstrate applicatio
 To add organizations to the system channel, enable the orderer and set the `systemChannel.organizations` value:
 
 ```yaml
-orderer:
+hlf-ord:
    enabled: true
 systemChannel:
    organizations:
@@ -149,7 +149,7 @@ This is done by configuring peers like so:
 
 
 ```yaml
-peer:
+hlf-peer:
    enabled: true
 
 # Add `MyOrg1` and `MyOrg2` to the application channel

--- a/charts/hlf-k8s/requirements.lock
+++ b/charts/hlf-k8s/requirements.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.29.7
-digest: sha256:072d7a387df6b60dc2e59d69a05117af7b20af29a03496fcb3ceb4e9b9200086
-generated: "2020-04-13T23:51:15.734874452-04:00"
+digest: sha256:1c84b0b5bae63a1fd24f8a860ffc1c0ae66e130d83983554167fd592a87824e4
+generated: "2020-05-13T11:19:46.233884+02:00"

--- a/charts/hlf-k8s/requirements.yaml
+++ b/charts/hlf-k8s/requirements.yaml
@@ -16,18 +16,15 @@ dependencies:
   - name: hlf-ca
     repository: https://kubernetes-charts.storage.googleapis.com/
     version: 1.2.0
-    alias: ca
-    condition: ca.enabled
+    condition: hlf-ca.enabled
   - name: hlf-ord
     repository: https://kubernetes-charts.storage.googleapis.com/
     version: 1.3.0
-    condition: orderer.enabled
-    alias: orderer
+    condition: hlf-ord.enabled
   - name: hlf-peer
     repository: https://kubernetes-charts.storage.googleapis.com/
     version: 1.3.0
-    condition: peer.enabled
-    alias: peer
+    condition: hlf-peer.enabled
   - name: nginx-ingress
     repository: https://kubernetes-charts.storage.googleapis.com/
     version: ~1.29.2

--- a/charts/hlf-k8s/templates/configmap-application-organization.yaml
+++ b/charts/hlf-k8s/templates/configmap-application-organization.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.peer.enabled }}
+{{- if index .Values "hlf-peer" "enabled" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/hlf-k8s/templates/configmap-application-proposal-organization.yaml
+++ b/charts/hlf-k8s/templates/configmap-application-proposal-organization.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.peer.enabled }}
+{{- if index .Values "hlf-peer" "enabled" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/hlf-k8s/templates/configmap-fabric.yaml
+++ b/charts/hlf-k8s/templates/configmap-fabric.yaml
@@ -33,16 +33,16 @@ data:
       Organizations: null
     Organizations:
     - &id001
-      {{- if .Values.peer.enabled }}
+      {{- if index .Values "hlf-peer" "enabled" }}
       AnchorPeers:
-      - Host: {{ .Values.peer.host }}
-        Port: {{ .Values.peer.port }}
+      - Host: {{ index .Values "hlf-peer" "host" }}
+        Port: {{ index .Values "hlf-peer" "port" }}
       {{- end }}
       ID: {{ .Values.organization.id }}
       MSPDir: /var/hyperledger/admin_msp
       Name: {{ .Values.organization.name }}
     Profiles:
-      {{- if .Values.peer.enabled }}
+      {{- if index .Values "hlf-peer" "enabled" }}
       OrgsChannel:
         Application:
           {{- if .Values.appChannel.policies }}
@@ -53,14 +53,14 @@ data:
           - *id001
         Consortium: SampleConsortium
       {{- end }}
-      {{- if .Values.orderer.enabled }}
+      {{- if index .Values "hlf-ord" "enabled" }}
       GenerateGenesis:
         Consortiums:
           SampleConsortium:
             Organizations: *id001
         Orderer:
           Addresses:
-          - {{ .Values.orderer.host }}:{{ .Values.orderer.port }}
+          - {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }}
           BatchSize:
             AbsoluteMaxBytes: 99 MB
             MaxMessageCount: 1
@@ -87,10 +87,10 @@ data:
             KeyStore: null
           Hash: SHA2
           Security: 256
-      {{- if .Values.orderer.enabled }}
-      address: {{ .Values.orderer.host }}:{{ .Values.orderer.port }}
+      {{- if index .Values "hlf-ord" "enabled" }}
+      address: {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }}
       {{- else }}
-      address: {{ .Values.peer.host }}:{{ .Values.peer.port }}
+      address: {{ index .Values "hlf-peer" "host" }}:{{ index .Values "hlf-peer" "port" }}
       {{- end }}
       addressAutoDetect: false
       adminService: null
@@ -123,10 +123,10 @@ data:
           membershipSampleInterval: 1s
           startupGracePeriod: 15s
         endpoint: null
-        {{- if .Values.orderer.enabled }}
-        externalEndpoint: {{ .Values.orderer.host }}:{{ .Values.orderer.port }}
+        {{- if index .Values "hlf-ord" "enabled" }}
+        externalEndpoint: {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }}
         {{- else }}
-        externalEndpoint: {{ .Values.peer.host }}:{{ .Values.peer.port }}
+        externalEndpoint: {{ index .Values "hlf-peer" "host" }}:{{ index .Values "hlf-peer" "port" }}
         {{- end }}
         maxBlockCountToStore: 100
         maxPropagationBurstLatency: 10ms

--- a/charts/hlf-k8s/templates/configmap-system-organizations.yaml
+++ b/charts/hlf-k8s/templates/configmap-system-organizations.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.orderer.enabled }}
+{{- if index .Values "hlf-ord" "enabled" }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/hlf-k8s/templates/deployment-application-channel-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-application-channel-operator.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.peer.enabled }}
+{{- if index .Values "hlf-peer" "enabled" }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -46,9 +46,9 @@ spec:
             update-ca-certificates
 
             ## Check connection with the Orderer
-            printf "[DEBUG] Testing the connection with the Orderer ({{ .Values.orderer.host }}:{{ .Values.orderer.port }})\n"
-            until $(nc -z {{ .Values.orderer.host }} {{ .Values.orderer.port }}); do
-              printf "[DEBUG] Orderer ({{ .Values.orderer.host }}:{{ .Values.orderer.port }}) is not reacheable, retry in 5s\n"
+            printf "[DEBUG] Testing the connection with the Orderer ({{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }})\n"
+            until $(nc -z {{ index .Values "hlf-ord" "host" }} {{ index .Values "hlf-ord" "port" }}); do
+              printf "[DEBUG] Orderer ({{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }}) is not reacheable, retry in 5s\n"
               sleep 5
             done
 
@@ -62,12 +62,12 @@ spec:
 
                 ## Create channel
                 configtxgen -profile OrgsChannel --outputCreateChannelTx channel.tx -channelID {{ .Values.appChannel.name }} -asOrg {{ .Values.organization.name }}
-                peer channel create -f channel.tx --outputBlock channel.block -c {{ .Values.appChannel.name }} -o {{ .Values.orderer.host }}:{{ .Values.orderer.port }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt 2> channel.created
+                peer channel create -f channel.tx --outputBlock channel.block -c {{ .Values.appChannel.name }} -o {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt 2> channel.created
 
                 ## Create and add anchor
                 configtxgen -profile OrgsChannel --outputAnchorPeersUpdate anchor.tx -channelID {{ .Values.appChannel.name }} -asOrg {{ .Values.organization.name }}
 
-                peer channel update -f anchor.tx -c {{ .Values.appChannel.name }} -o {{ .Values.orderer.host }}:{{ .Values.orderer.port }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt
+                peer channel update -f anchor.tx -c {{ .Values.appChannel.name }} -o {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt
 
                 sleep 1
               done
@@ -76,13 +76,13 @@ spec:
               until grep "{{ .Values.appChannel.name }}" channel.list > /dev/null; do
 
                 printf "[DEBUG] Fetching application channel block\n"
-                peer channel fetch oldest channeljoin.block -c {{ .Values.appChannel.name }} -o {{ .Values.orderer.host }}:{{ .Values.orderer.port }}  --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt
+                peer channel fetch oldest channeljoin.block -c {{ .Values.appChannel.name }} -o {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }}  --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt
 
                 printf "[DEBUG] Joining channel\n"
                 peer channel join -b channeljoin.block
 
                 ## Fetch channel list
-                peer channel list -o {{ .Values.orderer.host }}:{{ .Values.orderer.port }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt > channel.list
+                peer channel list -o {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt > channel.list
 
                 sleep 1
               done
@@ -101,7 +101,7 @@ spec:
                 ## Fetch up-to-date channel configuration block
                 until [ -f "channel.block" ] && [ -s "channel.block" ]; do
                   printf "[DEBUG] Fetching the channel ({{ .Values.appChannel.name }}) configuration block\n"
-                  peer channel fetch config channel.block -c {{ .Values.appChannel.name }} -o {{ .Values.orderer.host }}:{{ .Values.orderer.port }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt > /tmp/out.txt 2>&1 || cat /tmp/out.txt
+                  peer channel fetch config channel.block -c {{ .Values.appChannel.name }} -o {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt > /tmp/out.txt 2>&1 || cat /tmp/out.txt
                   sleep 3
                 done
 
@@ -189,7 +189,7 @@ spec:
                 fi
 
                 ## Sign update proposal
-                peer channel signconfigtx -f proposal-$org.pb -o {{ .Values.orderer.host }}:{{ .Values.orderer.port }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt
+                peer channel signconfigtx -f proposal-$org.pb -o {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt
 
                 ## Update proposal in /data
                 cp proposal-$org.pb /data/proposal-$org.pb
@@ -199,7 +199,7 @@ spec:
                 NUM_SIGNATURES=$(configtxlator proto_decode --input proposal-$org.pb --type common.Envelope | jq '.payload.data.signatures | map(.signature_header.creator.mspid) | unique | length')
                 NUM_APPLICATION_ORGS=$(wc -l /proposal/application-proposal-organizations | cut -c 1)
                 printf "[DEBUG] Submit channel update for '$org' with $NUM_SIGNATURES signatures (out of $NUM_APPLICATION_ORGS organizations)\n"
-                peer channel update -f proposal-$org.pb -c {{ .Values.appChannel.name }} -o {{ .Values.orderer.host }}:{{ .Values.orderer.port }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt
+                peer channel update -f proposal-$org.pb -c {{ .Values.appChannel.name }} -o {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt
 
                 sleep 5
 
@@ -209,7 +209,7 @@ spec:
               until grep "{{ .Values.appChannel.chaincodeName }}" chaincode.list | grep "{{ .Values.appChannel.chaincodeVersion }}" > /dev/null; do
 
                 printf "[DEBUG] Instantiate chaincode {{ .Values.appChannel.chaincodeName }} {{ .Values.appChannel.chaincodeVersion }} on channel {{ .Values.appChannel.name }} with policy : {{ .Values.appChannel.chaincodePolicy }}\n"
-                peer chaincode instantiate -C {{ .Values.appChannel.name }} -n {{ .Values.appChannel.chaincodeName }} -v {{ .Values.appChannel.chaincodeVersion }} -c '{"Args":["init"]}' -P "{{ .Values.appChannel.chaincodePolicy }}" -o {{ .Values.orderer.host }}:{{ .Values.orderer.port }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt
+                peer chaincode instantiate -C {{ .Values.appChannel.name }} -n {{ .Values.appChannel.chaincodeName }} -v {{ .Values.appChannel.chaincodeVersion }} -c '{"Args":["init"]}' -P "{{ .Values.appChannel.chaincodePolicy }}" -o {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }} --tls --clientauth --cafile /var/hyperledger/tls/ord/cert/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt
                 sleep 5
 
                 peer chaincode -C {{ .Values.appChannel.name }} list --instantiated > chaincode.list
@@ -291,31 +291,31 @@ spec:
             name: {{ template "substra.fullname" . }}-fabric
         - name: id-cert
           secret:
-            secretName: {{ .Values.peer.secrets.peer.cert }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "cert" }}
         - name: id-key
           secret:
-            secretName: {{ .Values.peer.secrets.peer.key }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "key" }}
         - name: cacert
           secret:
-            secretName: {{ .Values.peer.secrets.peer.caCert }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "caCert" }}
         - name: tls
           secret:
-            secretName: {{ .Values.peer.secrets.peer.tls }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "tls" }}
         - name: tls-rootcert
           secret:
-            secretName: {{ .Values.peer.secrets.peer.tlsRootCert }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "tlsRootCert" }}
         - name: tls-client
           secret:
-            secretName: {{ .Values.peer.secrets.peer.tlsClient }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "tlsClient" }}
         - name: tls-clientrootcert
           secret:
-            secretName: {{ .Values.peer.secrets.peer.tlsClientRootCert }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "tlsClientRootCert" }}
         - name: admin-cert
           secret:
-            secretName: {{ .Values.peer.secrets.adminCert }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "adminCert" }}
         - name: admin-key
           secret:
-            secretName: {{ .Values.peer.secrets.adminKey }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "adminKey" }}
         - name: ord-tls-rootcert
           secret:
             secretName: {{ .Values.secrets.ordTlsRootCert }}

--- a/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.peer.enabled }}
+{{- if index .Values "hlf-peer" "enabled" }}
 {{- range $index, $value := .Values.chaincodes }}
 ---
 apiVersion: apps/v1

--- a/charts/hlf-k8s/templates/deployment-config-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-config-operator.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.peer.enabled }}
+{{- if index .Values "hlf-peer" "enabled" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,7 +52,7 @@ spec:
 
                 until [ -f "/data/configOrgWithAnchors.json" ]; do
                   printf "[DEBUG] Create the org config anchor file\n"
-                  jq -s '.[0] * {"values":{"AnchorPeers":{"mod_policy":"Admins", "value":{"anchor_peers":[{"host":"{{ .Values.peer.host }}", "port":"{{ .Values.peer.port }}"}]}, "version": "0"}}}' /data/configOrg.json > /data/configOrgWithAnchors.json
+                  jq -s '.[0] * {"values":{"AnchorPeers":{"mod_policy":"Admins", "value":{"anchor_peers":[{"host":"{{ index .Values "hlf-peer" "host" }}", "port":"{{ index .Values "hlf-peer" "port" }}"}]}, "version": "0"}}}' /data/configOrg.json > /data/configOrgWithAnchors.json
                   sleep 1
                 done
 

--- a/charts/hlf-k8s/templates/deployment-enrollement-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-enrollement-operator.yaml
@@ -44,17 +44,17 @@ spec:
               update-ca-certificates
 
               ## Check connection with the Certificate Authority
-              printf "[DEBUG] Testing the connection with this node's Certificate Authority ({{ .Values.ca.scheme }}://{{ .Values.ca.host }}:{{ .Values.ca.port }})\n"
-              until fabric-ca-client getcainfo -u {{ .Values.ca.scheme }}://{{ .Values.ca.host }}:{{ .Values.ca.port }}; do
-                printf "[DEBUG] Certificate Authority ({{ .Values.ca.scheme }}://{{ .Values.ca.host }}:{{ .Values.ca.port }}) server is not reacheable, retry in 5s\n"
+              printf "[DEBUG] Testing the connection with this node's Certificate Authority ({{ index .Values "hlf-ca" "scheme" }}://{{ index .Values "hlf-ca" "host" }}:{{ index .Values "hlf-ca" "port" }})\n"
+              until fabric-ca-client getcainfo -u {{ index .Values "hlf-ca" "scheme" }}://{{ index .Values "hlf-ca" "host" }}:{{ index .Values "hlf-ca" "port" }}; do
+                printf "[DEBUG] Certificate Authority ({{ index .Values "hlf-ca" "scheme" }}://{{ index .Values "hlf-ca" "host" }}:{{ index .Values "hlf-ca" "port" }}) server is not reacheable, retry in 5s\n"
                 sleep 5
               done
 
               ## Enroll CA administrator
               printf "[DEBUG] Testing enrollment of CA admin\n"
-              until fabric-ca-client identity list -u {{ .Values.ca.scheme }}://{{ .Values.ca.adminUsername }}:{{ .Values.ca.adminPassword }}@{{ .Values.ca.host }}:{{ .Values.ca.port }} --id {{ .Values.ca.adminUsername }}; do
+              until fabric-ca-client identity list -u {{ index .Values "hlf-ca" "scheme" }}://{{ index .Values "hlf-ca" "adminUsername" }}:{{ index .Values "hlf-ca" "adminPassword" }}@{{ index .Values "hlf-ca" "host" }}:{{ index .Values "hlf-ca" "port" }} --id {{ index .Values "hlf-ca" "adminUsername" }}; do
                 printf "[DEBUG] Certificate Authority admin is not enrolled, enrolling it now:\n"
-                fabric-ca-client enroll -d -u {{ .Values.ca.scheme }}://{{ .Values.ca.adminUsername }}:{{ .Values.ca.adminPassword }}@{{ .Values.ca.host }}:{{ .Values.ca.port }} -M /var/hyperledger/fabric-ca/msp
+                fabric-ca-client enroll -d -u {{ index .Values "hlf-ca" "scheme" }}://{{ index .Values "hlf-ca" "adminUsername" }}:{{ index .Values "hlf-ca" "adminPassword" }}@{{ index .Values "hlf-ca" "host" }}:{{ index .Values "hlf-ca" "port" }} -M /var/hyperledger/fabric-ca/msp
                 sleep 1
               done
 
@@ -67,9 +67,9 @@ spec:
               done
 
               ## Check connection with the Orderer Certificate Authority
-              printf "[DEBUG] Testing the connection with the Orderer Certificate Authority ({{ .Values.ca.orderer.scheme }}://{{ .Values.ca.orderer.host }}:{{ .Values.ca.orderer.port}})\n"
-              until fabric-ca-client getcainfo -u {{ .Values.ca.orderer.scheme }}://{{ .Values.ca.orderer.host }}:{{ .Values.ca.orderer.port }} -H /tmp/orderer; do
-                printf "[DEBUG] Orderer Certificate Authority ({{ .Values.ca.orderer.scheme }}://{{ .Values.ca.orderer.host }}:{{ .Values.ca.orderer.port}}) server is not reacheable, retry in 5s\n"
+              printf "[DEBUG] Testing the connection with the Orderer Certificate Authority ({{ index .Values "hlf-ca" "orderer" "scheme" }}://{{ index .Values "hlf-ca" "orderer" "host" }}:{{ index .Values "hlf-ca" "orderer" "port"}})\n"
+              until fabric-ca-client getcainfo -u {{ index .Values "hlf-ca" "orderer" "scheme" }}://{{ index .Values "hlf-ca" "orderer" "host" }}:{{ index .Values "hlf-ca" "orderer" "port" }} -H /tmp/orderer; do
+                printf "[DEBUG] Orderer Certificate Authority ({{ index .Values "hlf-ca" "orderer" "scheme" }}://{{ index .Values "hlf-ca" "orderer" "host" }}:{{ index .Values "hlf-ca" "orderer" "port"}}) server is not reacheable, retry in 5s\n"
                 sleep 5
               done
 
@@ -88,23 +88,23 @@ spec:
                   printf "[DEBUG] Checking enrollment of CA user $name\n"
 
                   ## Register user
-                  until fabric-ca-client identity list -u {{ .Values.ca.scheme }}://{{ .Values.ca.adminUsername }}:{{ .Values.ca.adminPassword }}@{{ .Values.ca.host }}:{{ .Values.ca.port }} --id $name; do
+                  until fabric-ca-client identity list -u {{ index .Values "hlf-ca" "scheme" }}://{{ index .Values "hlf-ca" "adminUsername" }}:{{ index .Values "hlf-ca" "adminPassword" }}@{{ index .Values "hlf-ca" "host" }}:{{ index .Values "hlf-ca" "port" }} --id $name; do
                     printf "[DEBUG] User $name is not registered, registering the user now:\n"
-                    fabric-ca-client register -d -u {{ .Values.ca.scheme }}://{{ .Values.ca.adminUsername }}:{{ .Values.ca.adminPassword }}@{{ .Values.ca.host }}:{{ .Values.ca.port }} --id.name $name --id.secret $secret $options
+                    fabric-ca-client register -d -u {{ index .Values "hlf-ca" "scheme" }}://{{ index .Values "hlf-ca" "adminUsername" }}:{{ index .Values "hlf-ca" "adminPassword" }}@{{ index .Values "hlf-ca" "host" }}:{{ index .Values "hlf-ca" "port" }} --id.name $name --id.secret $secret $options
                     sleep 1
                   done
 
                   ## Enroll user (MSP)
                   until [ -d "/data/$name/msp" ]; do
                     printf "[DEBUG] MSP certificate not found: enrolling user '$name' now:\n"
-                    fabric-ca-client enroll -d -u {{ .Values.ca.scheme }}://$name:$secret@{{ .Values.ca.host }}:{{ .Values.ca.port }} -M /data/$name/msp
+                    fabric-ca-client enroll -d -u {{ index .Values "hlf-ca" "scheme" }}://$name:$secret@{{ index .Values "hlf-ca" "host" }}:{{ index .Values "hlf-ca" "port" }} -M /data/$name/msp
                     sleep 1
                   done
 
                   ## Enroll user (TLS)
                   until [ -d "/data/$name/tls" ]; do
                     printf "[DEBUG] TLS certificate not found: enrolling user '$name' with TLS profile now:\n"
-                    fabric-ca-client enroll -d --enrollment.profile tls -u {{ .Values.ca.scheme }}://$name:$secret@{{ .Values.ca.host }}:{{ .Values.ca.port }} -M /data/$name/tls --csr.hosts {{ .Values.enrollments.csrHost }}
+                    fabric-ca-client enroll -d --enrollment.profile tls -u {{ index .Values "hlf-ca" "scheme" }}://$name:$secret@{{ index .Values "hlf-ca" "host" }}:{{ index .Values "hlf-ca" "port" }} -M /data/$name/tls --csr.hosts {{ .Values.enrollments.csrHost }}
                     sleep 1
                   done
 

--- a/charts/hlf-k8s/templates/deployment-genesis-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-genesis-operator.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.orderer.enabled }}
+{{- if index .Values "hlf-ord" "enabled" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -105,31 +105,31 @@ spec:
           name: {{ template "substra.fullname" . }}-fabric
       - name: id-cert
         secret:
-          secretName: {{ .Values.orderer.secrets.ord.cert }}
+          secretName: {{ index .Values "hlf-ord" "secrets" "ord" "cert" }}
       - name: id-key
         secret:
-          secretName: {{ .Values.orderer.secrets.ord.key }}
+          secretName: {{ index .Values "hlf-ord" "secrets" "ord" "key" }}
       - name: cacert
         secret:
-          secretName: {{ .Values.orderer.secrets.ord.caCert }}
+          secretName: {{ index .Values "hlf-ord" "secrets" "ord" "caCert" }}
       - name: tls
         secret:
-          secretName: {{ .Values.orderer.secrets.ord.tls }}
+          secretName: {{ index .Values "hlf-ord" "secrets" "ord" "tls" }}
       - name: tls-rootcert
         secret:
-          secretName: {{ .Values.orderer.secrets.ord.tlsRootCert }}
+          secretName: {{ index .Values "hlf-ord" "secrets" "ord" "tlsRootCert" }}
       - name: tls-client
         secret:
-          secretName: {{ .Values.orderer.secrets.ord.tlsClient }}
+          secretName: {{ index .Values "hlf-ord" "secrets" "ord" "tlsClient" }}
       - name: tls-clientrootcert
         secret:
-          secretName: {{ .Values.orderer.secrets.ord.tlsClientRootCert }}
+          secretName: {{ index .Values "hlf-ord" "secrets" "ord" "tlsClientRootCert" }}
       - name: admin-cert
         secret:
-          secretName: {{ .Values.orderer.secrets.adminCert }}
+          secretName: {{ index .Values "hlf-ord" "secrets" "adminCert" }}
       - name: admin-key
         secret:
-          secretName: {{ .Values.orderer.secrets.adminKey }}
+          secretName: {{ index .Values "hlf-ord" "secrets" "adminKey" }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/hlf-k8s/templates/deployment-monitor.yaml
+++ b/charts/hlf-k8s/templates/deployment-monitor.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if and .Values.orderer.enabled .Values.orderer.monitor.enabled }}
+{{- if and (index .Values "hlf-ord" "enabled") (index .Values "hlf-ord" "monitor" "enabled") }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -46,9 +46,9 @@ spec:
             update-ca-certificates
 
             ## Check connection with the Orderer
-            printf "[DEBUG] Testing the connection with the Orderer ({{ .Values.orderer.host }}:{{ .Values.orderer.port }})\n"
-            until $(nc -z {{ .Values.orderer.host }} {{ .Values.orderer.port }}); do
-              printf "[DEBUG] Orderer ({{ .Values.orderer.host }}:{{ .Values.orderer.port }}) is not reacheable, retry in 3s\n"
+            printf "[DEBUG] Testing the connection with the Orderer ({{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }})\n"
+            until $(nc -z {{ index .Values "hlf-ord" "host" }} {{ index .Values "hlf-ord" "port" }}); do
+              printf "[DEBUG] Orderer ({{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }}) is not reacheable, retry in 3s\n"
               sleep 3
             done
 
@@ -58,7 +58,7 @@ spec:
 
               peer channel fetch config systemChannel.block \
                 -c {{ .Values.systemChannel.name }} \
-                -o {{ .Values.orderer.host }}:{{ .Values.orderer.port }} \
+                -o {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }} \
                 --tls \
                 --clientauth \
                 --cafile /var/hyperledger/tls/ord/cert/cacert.pem \
@@ -73,7 +73,7 @@ spec:
 
               peer channel fetch config applicationChannel.block \
                 -c {{ .Values.appChannel.name }} \
-                -o {{ .Values.orderer.host }}:{{ .Values.orderer.port }} \
+                -o {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }} \
                 --tls \
                 --clientauth \
                 --cafile /var/hyperledger/tls/ord/cert/cacert.pem \
@@ -137,31 +137,31 @@ spec:
             name: {{ template "substra.fullname" . }}-fabric
         - name: id-cert
           secret:
-            secretName: {{ .Values.peer.secrets.peer.cert }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "cert" }}
         - name: id-key
           secret:
-            secretName: {{ .Values.peer.secrets.peer.key }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "key" }}
         - name: cacert
           secret:
-            secretName: {{ .Values.peer.secrets.peer.caCert }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "caCert" }}
         - name: tls
           secret:
-            secretName: {{ .Values.peer.secrets.peer.tls }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "tls" }}
         - name: tls-rootcert
           secret:
-            secretName: {{ .Values.peer.secrets.peer.tlsRootCert }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "tlsRootCert" }}
         - name: tls-client
           secret:
-            secretName: {{ .Values.peer.secrets.peer.tlsClient }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "tlsClient" }}
         - name: tls-clientrootcert
           secret:
-            secretName: {{ .Values.peer.secrets.peer.tlsClientRootCert }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "peer" "tlsClientRootCert" }}
         - name: admin-cert
           secret:
-            secretName: {{ .Values.peer.secrets.adminCert }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "adminCert" }}
         - name: admin-key
           secret:
-            secretName: {{ .Values.peer.secrets.adminKey }}
+            secretName: {{ index .Values "hlf-peer" "secrets" "adminKey" }}
         - name: ord-tls-rootcert
           secret:
             secretName: {{ .Values.secrets.ordTlsRootCert }}

--- a/charts/hlf-k8s/templates/deployment-system-channel-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-system-channel-operator.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.orderer.enabled }}
+{{- if index .Values "hlf-ord" "enabled" }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -46,9 +46,9 @@ spec:
             update-ca-certificates
 
             ## Check connection with the Orderer
-            printf "[DEBUG] Testing the connection with the Orderer ({{ .Values.orderer.host }}:{{ .Values.orderer.port }})\n"
-            until $(nc -z {{ .Values.orderer.host }} {{ .Values.orderer.port }}); do
-              printf "[DEBUG] Orderer ({{ .Values.orderer.host }}:{{ .Values.orderer.port }}) is not reacheable, retry in 5s\n"
+            printf "[DEBUG] Testing the connection with the Orderer ({{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }})\n"
+            until $(nc -z {{ index .Values "hlf-ord" "host" }} {{ index .Values "hlf-ord" "port" }}); do
+              printf "[DEBUG] Orderer ({{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }}) is not reacheable, retry in 5s\n"
               sleep 5
             done
 
@@ -68,7 +68,7 @@ spec:
                 ## Fetch system channel configuration block
                 until [ -f "channel.block" ] && [ -s "channel.block" ]; do
                   printf "[DEBUG] Fetching the system channel ({{ .Values.systemChannel.name }}) configuration block\n"
-                  peer channel fetch config channel.block -c {{ .Values.systemChannel.name }} -o {{ .Values.orderer.host }}:{{ .Values.orderer.port }} --tls --clientauth --cafile /var/hyperledger/msp/cacerts/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt > /tmp/out.txt 2>&1 || cat /tmp/out.txt
+                  peer channel fetch config channel.block -c {{ .Values.systemChannel.name }} -o {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }} --tls --clientauth --cafile /var/hyperledger/msp/cacerts/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt > /tmp/out.txt 2>&1 || cat /tmp/out.txt
                   sleep 3
                 done
 
@@ -123,12 +123,12 @@ spec:
                 until $(grep "$org" channelconfignew-$org.json > /dev/null 2> /dev/null); do
 
                   printf "[DEBUG] Send system channel update proposal for $org\n"
-                  peer channel update -f proposal-$org.pb -c {{ .Values.systemChannel.name }} -o {{ .Values.orderer.host }}:{{ .Values.orderer.port }} --tls --clientauth --cafile /var/hyperledger/msp/cacerts/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt
+                  peer channel update -f proposal-$org.pb -c {{ .Values.systemChannel.name }} -o {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }} --tls --clientauth --cafile /var/hyperledger/msp/cacerts/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt
 
                   sleep 2
 
                   printf "[DEBUG] Fetch system channel configuration to check the update for $org\n"
-                  peer channel fetch config channelnew-$org.block -c {{ .Values.systemChannel.name }} -o {{ .Values.orderer.host }}:{{ .Values.orderer.port }} --tls --clientauth --cafile /var/hyperledger/msp/cacerts/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt > /tmp/out.txt 2>&1 || cat /tmp/out.txt
+                  peer channel fetch config channelnew-$org.block -c {{ .Values.systemChannel.name }} -o {{ index .Values "hlf-ord" "host" }}:{{ index .Values "hlf-ord" "port" }} --tls --clientauth --cafile /var/hyperledger/msp/cacerts/cacert.pem --keyfile /var/hyperledger/tls/client/pair/tls.key --certfile /var/hyperledger/tls/client/pair/tls.crt > /tmp/out.txt 2>&1 || cat /tmp/out.txt
                   configtxlator proto_decode --input channelnew-$org.block --type common.Block | jq .data.data[0].payload.data.config > channelconfignew-$org.json
 
                   sleep 5
@@ -194,31 +194,31 @@ spec:
             name: {{ template "substra.fullname" . }}-fabric
         - name: id-cert
           secret:
-            secretName: {{ .Values.orderer.secrets.ord.cert }}
+            secretName: {{ index .Values "hlf-ord" "secrets" "ord" "cert" }}
         - name: id-key
           secret:
-            secretName: {{ .Values.orderer.secrets.ord.key }}
+            secretName: {{ index .Values "hlf-ord" "secrets" "ord" "key" }}
         - name: cacert
           secret:
-            secretName: {{ .Values.orderer.secrets.ord.caCert }}
+            secretName: {{ index .Values "hlf-ord" "secrets" "ord" "caCert" }}
         - name: tls
           secret:
-            secretName: {{ .Values.orderer.secrets.ord.tls }}
+            secretName: {{ index .Values "hlf-ord" "secrets" "ord" "tls" }}
         - name: tls-rootcert
           secret:
-            secretName: {{ .Values.orderer.secrets.ord.tlsRootCert }}
+            secretName: {{ index .Values "hlf-ord" "secrets" "ord" "tlsRootCert" }}
         - name: tls-client
           secret:
-            secretName: {{ .Values.orderer.secrets.ord.tlsClient }}
+            secretName: {{ index .Values "hlf-ord" "secrets" "ord" "tlsClient" }}
         - name: tls-clientrootcert
           secret:
-            secretName: {{ .Values.orderer.secrets.ord.tlsClientRootCert }}
+            secretName: {{ index .Values "hlf-ord" "secrets" "ord" "tlsClientRootCert" }}
         - name: admin-cert
           secret:
-            secretName: {{ .Values.orderer.secrets.adminCert }}
+            secretName: {{ index .Values "hlf-ord" "secrets" "adminCert" }}
         - name: admin-key
           secret:
-            secretName: {{ .Values.orderer.secrets.adminKey }}
+            secretName: {{ index .Values "hlf-ord" "secrets" "adminKey" }}
         {{- if .Values.privateCa.enabled }}
         - name: private-ca
           configMap:

--- a/charts/hlf-k8s/templates/job-hook-uninstall-chaincode.yaml
+++ b/charts/hlf-k8s/templates/job-hook-uninstall-chaincode.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if and (.Values.peer.enabled) (.Values.hooks.uninstallChaincode.enabled) }}
+{{- if and (index .Values "hlf-peer" "enabled") (.Values.hooks.uninstallChaincode.enabled) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -98,7 +98,7 @@ organization:
   id: MyOrganizationMSP
   name: MyOrganization
 
-ca:
+hlf-ca:
   enabled: true
   scheme: http
   host: ca-hostname
@@ -133,7 +133,7 @@ ca:
     host: orderer-ca-hostname
     port: 7054
 
-peer:
+hlf-peer:
   peer:
     gossip:
       bootstrap: "127.0.0.1:7051"
@@ -179,7 +179,7 @@ peer:
     ## This should include the Orderer TLS 'cacert.pem'
     ordTlsRootCert: ord-tls-rootcert
 
-orderer:
+hlf-ord:
   enabled: false
   host: orderer-hostname
   port: 7050

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -38,28 +38,28 @@ deploy:
           image: substrafoundation/hlf-k8s
         setValues:
           nginx-ingress.enabled: true
-          peer.enabled: false
-          ca.caName: rcaOrderer
-          ca.host: network-orderer-ca.orderer
-          ca.orderer.host: network-orderer-ca.orderer
+          hlf-peer.enabled: false
+          hlf-ca.caName: rcaOrderer
+          hlf-ca.host: network-orderer-hlf-ca.orderer
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
           organization.id: MyOrdererMSP
           organization.name: MyOrderer
-          orderer.enabled: true
-          orderer.monitor.enabled: true
+          hlf-ord.enabled: true
+          hlf-ord.monitor.enabled: true
           # Add Org to system channel to allows them to adminstrate application channels
           systemChannel.organizations[0].org: MyOrg1
           systemChannel.organizations[0].configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrg.json
           systemChannel.organizations[1].org: MyOrg2
           systemChannel.organizations[1].configUrl: network-org-2-peer-1-hlf-k8s-config-operator.org-2/config/configOrg.json
-          orderer.host: network-orderer.orderer
-          orderer.ord.mspID: MyOrdererMSP
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-ord.ord.mspID: MyOrdererMSP
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs admin=true:ecert"
           enrollments.creds[1].name: user
           enrollments.creds[1].secret: pwd
           enrollments.creds[1].options: "--id.type orderer"
-          enrollments.csrHost: network-orderer.orderer
+          enrollments.csrHost: network-orderer-hlf-ord.orderer
           toolbox.enabled: true
 
       - name: network-org-1-peer-1
@@ -72,13 +72,13 @@ deploy:
         setValues:
           nginx-ingress.enabled: true
           nginx-ingress.controller.scope.enabled: true
-          ca.caName: rcaOrg1
-          ca.host: network-org-1-peer-1-ca.org-1
-          ca.orderer.host: network-orderer-ca.orderer
-          peer.host: network-org-1-peer-1.org-1
+          hlf-ca.caName: rcaOrg1
+          hlf-ca.host: network-org-1-peer-1-hlf-ca.org-1
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
+          hlf-peer.host: network-org-1-peer-1-hlf-peer.org-1
           organization.id: MyOrg1MSP
           organization.name: MyOrg1
-          peer.peer.mspID: MyOrg1MSP
+          hlf-peer.peer.mspID: MyOrg1MSP
           chaincodes[0].instantiate: true
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
@@ -101,15 +101,15 @@ deploy:
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member')
           appChannel.chaincodeName: mycc
           appChannel.chaincodeVersion: "1.0"
-          orderer.host: network-orderer.orderer
-          peer.peer.gossip.externalEndpoint: network-org-1-peer-1.org-1:7051
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-peer.peer.gossip.externalEndpoint: network-org-1-peer-1-hlf-peer.org-1:7051
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
           enrollments.creds[1].name: user,
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
-          enrollments.csrHost: network-org-1-peer-1.org-1
+          enrollments.csrHost: network-org-1-peer-1-hlf-peer.org-1
           toolbox.enabled: true
 
 
@@ -123,13 +123,13 @@ deploy:
         setValues:
           nginx-ingress.enabled: true
           nginx-ingress.controller.scope.enabled: true
-          ca.caName: rcaOrg2
-          ca.host: network-org-2-peer-1-ca.org-2
-          ca.orderer.host: network-orderer-ca.orderer
-          peer.host: network-org-2-peer-1.org-2
+          hlf-ca.caName: rcaOrg2
+          hlf-ca.host: network-org-2-peer-1-hlf-ca.org-2
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
+          hlf-peer.host: network-org-2-peer-1-hlf-peer.org-2
           organization.id: MyOrg2MSP
           organization.name: MyOrg2
-          peer.peer.mspID: MyOrg2MSP
+          hlf-peer.peer.mspID: MyOrg2MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
@@ -137,14 +137,14 @@ deploy:
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member')
           appChannel.chaincodeName: mycc
           appChannel.chaincodeVersion: "1.0"
-          orderer.host: network-orderer.orderer
-          peer.peer.gossip.externalEndpoint: network-org-2-peer-1.org-2:7051
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-peer.peer.gossip.externalEndpoint: network-org-2-peer-1-hlf-peer.org-2:7051
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
           enrollments.creds[1].name: user,
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
-          enrollments.csrHost: network-org-2-peer-1.org-2
+          enrollments.csrHost: network-org-2-peer-1-hlf-peer.org-2
           toolbox.enabled: true
 

--- a/tools/skaffold-3orgs.yaml
+++ b/tools/skaffold-3orgs.yaml
@@ -44,14 +44,14 @@ deploy:
           image: substrafoundation/hlf-k8s
         setValues:
           nginx-ingress.enabled: true
-          peer.enabled: false
-          ca.caName: rcaOrderer
-          ca.host: network-orderer-ca.orderer
-          ca.orderer.host: network-orderer-ca.orderer
+          hlf-peer.enabled: false
+          hlf-ca.caName: rcaOrderer
+          hlf-ca.host: network-orderer-hlf-ca.orderer
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
           organization.id: MyOrdererMSP
           organization.name: MyOrderer
-          orderer.enabled: true
-          orderer.monitor.enabled: true
+          hlf-ord.enabled: true
+          hlf-ord.monitor.enabled: true
           # Add Org to system channel to allows them to adminstrate application channels
           systemChannel.organizations[0].org: MyOrg1
           systemChannel.organizations[0].configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrg.json
@@ -59,15 +59,15 @@ deploy:
           systemChannel.organizations[1].configUrl: network-org-2-peer-1-hlf-k8s-config-operator.org-2/config/configOrg.json
           systemChannel.organizations[2].org: MyOrg3
           systemChannel.organizations[2].configUrl: network-org-3-peer-1-hlf-k8s-config-operator.org-3/config/configOrg.json
-          orderer.host: network-orderer.orderer
-          orderer.ord.mspID: MyOrdererMSP
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-ord.ord.mspID: MyOrdererMSP
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs admin=true:ecert"
           enrollments.creds[1].name: user
           enrollments.creds[1].secret: pwd
           enrollments.creds[1].options: "--id.type orderer"
-          enrollments.csrHost: network-orderer.orderer
+          enrollments.csrHost: network-orderer-hlf-ord.orderer
           toolbox.enabled: true
 
       - name: network-org-1-peer-1
@@ -80,13 +80,13 @@ deploy:
         setValues:
           nginx-ingress.enabled: true
           nginx-ingress.controller.scope.enabled: true
-          ca.caName: rcaOrg1
-          ca.host: network-org-1-peer-1-ca.org-1
-          ca.orderer.host: network-orderer-ca.orderer
-          peer.host: network-org-1-peer-1.org-1
+          hlf-ca.caName: rcaOrg1
+          hlf-ca.host: network-org-1-peer-1-hlf-ca.org-1
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
+          hlf-peer.host: network-org-1-peer-1-hlf-peer.org-1
           organization.id: MyOrg1MSP
           organization.name: MyOrg1
-          peer.peer.mspID: MyOrg1MSP
+          hlf-peer.peer.mspID: MyOrg1MSP
           chaincodes[0].instantiate: true
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
@@ -108,15 +108,15 @@ deploy:
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member'\,'MyOrg3MSP.member')
           appChannel.chaincodeName: mycc
           appChannel.chaincodeVersion: "1.0"
-          orderer.host: network-orderer.orderer
-          peer.peer.gossip.externalEndpoint: network-org-1-peer-1.org-1:7051
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-peer.peer.gossip.externalEndpoint: network-org-1-peer-1-hlf-peer.org-1:7051
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
           enrollments.creds[1].name: user,
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
-          enrollments.csrHost: network-org-1-peer-1.org-1
+          enrollments.csrHost: network-org-1-peer-1-hlf-peer.org-1
           toolbox.enabled: true
 
 
@@ -130,13 +130,13 @@ deploy:
         setValues:
           nginx-ingress.enabled: true
           nginx-ingress.controller.scope.enabled: true
-          ca.caName: rcaOrg2
-          ca.host: network-org-2-peer-1-ca.org-2
-          ca.orderer.host: network-orderer-ca.orderer
-          peer.host: network-org-2-peer-1.org-2
+          hlf-ca.caName: rcaOrg2
+          hlf-ca.host: network-org-2-peer-1-hlf-ca.org-2
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
+          hlf-peer.host: network-org-2-peer-1-hlf-peer.org-2
           organization.id: MyOrg2MSP
           organization.name: MyOrg2
-          peer.peer.mspID: MyOrg2MSP
+          hlf-peer.peer.mspID: MyOrg2MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
@@ -157,15 +157,15 @@ deploy:
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member'\,'MyOrg3MSP.member')
           appChannel.chaincodeName: mycc
           appChannel.chaincodeVersion: "1.0"
-          orderer.host: network-orderer.orderer
-          peer.peer.gossip.externalEndpoint: network-org-2-peer-1.org-2:7051
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-peer.peer.gossip.externalEndpoint: network-org-2-peer-1-hlf-peer.org-2:7051
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
           enrollments.creds[1].name: user,
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
-          enrollments.csrHost: network-org-2-peer-1.org-2
+          enrollments.csrHost: network-org-2-peer-1-hlf-peer.org-2
           toolbox.enabled: true
 
 
@@ -179,13 +179,13 @@ deploy:
         setValues:
           nginx-ingress.enabled: true
           nginx-ingress.controller.scope.enabled: true
-          ca.caName: rcaOrg3
-          ca.host: network-org-3-peer-1-ca.org-3
-          ca.orderer.host: network-orderer-ca.orderer
-          peer.host: network-org-3-peer-1.org-3
+          hlf-ca.caName: rcaOrg3
+          hlf-ca.host: network-org-3-peer-1-hlf-ca.org-3
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
+          hlf-peer.host: network-org-3-peer-1-hlf-peer.org-3
           organization.id: MyOrg3MSP
           organization.name: MyOrg3
-          peer.peer.mspID: MyOrg3MSP
+          hlf-peer.peer.mspID: MyOrg3MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
@@ -205,13 +205,13 @@ deploy:
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member'\,'MyOrg3MSP.member')
           appChannel.chaincodeName: mycc
           appChannel.chaincodeVersion: "1.0"
-          orderer.host: network-orderer.orderer
-          peer.peer.gossip.externalEndpoint: network-org-3-peer-1.org-3:7051
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-peer.peer.gossip.externalEndpoint: network-org-3-peer-1-hlf-peer.org-3:7051
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
           enrollments.creds[1].name: user,
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
-          enrollments.csrHost: network-org-3-peer-1.org-3
+          enrollments.csrHost: network-org-3-peer-1-hlf-peer.org-3
           toolbox.enabled: true

--- a/tools/skaffold-4orgs-policy-any.yaml
+++ b/tools/skaffold-4orgs-policy-any.yaml
@@ -44,14 +44,14 @@ deploy:
           image: substrafoundation/hlf-k8s
         setValues:
           nginx-ingress.enabled: true
-          peer.enabled: false
-          ca.caName: rcaOrderer
-          ca.host: network-orderer-ca.orderer
-          ca.orderer.host: network-orderer-ca.orderer
+          hlf-peer.enabled: false
+          hlf-ca.caName: rcaOrderer
+          hlf-ca.host: network-orderer-hlf-ca.orderer
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
           organization.id: MyOrdererMSP
           organization.name: MyOrderer
-          orderer.enabled: true
-          orderer.monitor.enabled: true
+          hlf-ord.enabled: true
+          hlf-ord.monitor.enabled: true
           # Add Org to system channel to allows them to adminstrate application channels
           systemChannel.organizations[0].org: MyOrg1
           systemChannel.organizations[0].configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrg.json
@@ -61,15 +61,15 @@ deploy:
           systemChannel.organizations[2].configUrl: network-org-3-peer-1-hlf-k8s-config-operator.org-3/config/configOrg.json
           systemChannel.organizations[3].org: MyOrg4
           systemChannel.organizations[3].configUrl: network-org-3-peer-1-hlf-k8s-config-operator.org-3/config/configOrg.json
-          orderer.host: network-orderer.orderer
-          orderer.ord.mspID: MyOrdererMSP
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-ord.ord.mspID: MyOrdererMSP
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs admin=true:ecert"
           enrollments.creds[1].name: user
           enrollments.creds[1].secret: pwd
           enrollments.creds[1].options: "--id.type orderer"
-          enrollments.csrHost: network-orderer.orderer
+          enrollments.csrHost: network-orderer-hlf-ord.orderer
           toolbox.enabled: true
 
       - name: network-org-1-peer-1
@@ -82,13 +82,13 @@ deploy:
         setValues:
           nginx-ingress.enabled: true
           nginx-ingress.controller.scope.enabled: true
-          ca.caName: rcaOrg1
-          ca.host: network-org-1-peer-1-ca.org-1
-          ca.orderer.host: network-orderer-ca.orderer
-          peer.host: network-org-1-peer-1.org-1
+          hlf-ca.caName: rcaOrg1
+          hlf-ca.host: network-org-1-peer-1-hlf-ca.org-1
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
+          hlf-peer.host: network-org-1-peer-1-hlf-peer.org-1
           organization.id: MyOrg1MSP
           organization.name: MyOrg1
-          peer.peer.mspID: MyOrg1MSP
+          hlf-peer.peer.mspID: MyOrg1MSP
           chaincodes[0].instantiate: true
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
@@ -116,15 +116,15 @@ deploy:
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member'\,'MyOrg3MSP.member'\,'MyOrg4MSP.member')
           appChannel.chaincodeName: mycc
           appChannel.chaincodeVersion: "1.0"
-          orderer.host: network-orderer.orderer
-          peer.peer.gossip.externalEndpoint: network-org-1-peer-1.org-1:7051  :{port}
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-peer.peer.gossip.externalEndpoint: network-org-1-peer-1-hlf-peer.org-1:7051  :{port}
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
           enrollments.creds[1].name: user,
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
-          enrollments.csrHost: network-org-1-peer-1.org-1
+          enrollments.csrHost: network-org-1-peer-1-hlf-peer.org-1
           toolbox.enabled: true
 
 
@@ -138,13 +138,13 @@ deploy:
         setValues:
           nginx-ingress.enabled: true
           nginx-ingress.controller.scope.enabled: true
-          ca.caName: rcaOrg2
-          ca.host: network-org-2-peer-1-ca.org-2
-          ca.orderer.host: network-orderer-ca.orderer
-          peer.host: network-org-2-peer-1.org-2
+          hlf-ca.caName: rcaOrg2
+          hlf-ca.host: network-org-2-peer-1-hlf-ca.org-2
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
+          hlf-peer.host: network-org-2-peer-1-hlf-peer.org-2
           organization.id: MyOrg2MSP
           organization.name: MyOrg2
-          peer.peer.mspID: MyOrg2MSP
+          hlf-peer.peer.mspID: MyOrg2MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
@@ -152,15 +152,15 @@ deploy:
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member'\,'MyOrg3MSP.member'\,'MyOrg4MSP.member')
           appChannel.chaincodeName: mycc
           appChannel.chaincodeVersion: "1.0"
-          orderer.host: network-orderer.orderer
-          peer.peer.gossip.externalEndpoint: network-org-2-peer-1.org-2:7051  :{port}
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-peer.peer.gossip.externalEndpoint: network-org-2-peer-1-hlf-peer.org-2:7051  :{port}
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
           enrollments.creds[1].name: user,
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
-          enrollments.csrHost: network-org-2-peer-1.org-2
+          enrollments.csrHost: network-org-2-peer-1-hlf-peer.org-2
           toolbox.enabled: true
 
 
@@ -174,13 +174,13 @@ deploy:
         setValues:
           nginx-ingress.enabled: true
           nginx-ingress.controller.scope.enabled: true
-          ca.caName: rcaOrg3
-          ca.host: network-org-3-peer-1-ca.org-3
-          ca.orderer.host: network-orderer-ca.orderer
-          peer.host: network-org-3-peer-1.org-3
+          hlf-ca.caName: rcaOrg3
+          hlf-ca.host: network-org-3-peer-1-hlf-ca.org-3
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
+          hlf-peer.host: network-org-3-peer-1-hlf-peer.org-3
           organization.id: MyOrg3MSP
           organization.name: MyOrg3
-          peer.peer.mspID: MyOrg3MSP
+          hlf-peer.peer.mspID: MyOrg3MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
@@ -189,15 +189,15 @@ deploy:
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member'\,'MyOrg3MSP.member'\,'MyOrg4MSP.member')
           appChannel.chaincodeName: mycc
           appChannel.chaincodeVersion: "1.0"
-          orderer.host: network-orderer.orderer
-          peer.peer.gossip.externalEndpoint: network-org-3-peer-1.org-3:7051  :{port}
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-peer.peer.gossip.externalEndpoint: network-org-3-peer-1-hlf-peer.org-3:7051  :{port}
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
           enrollments.creds[1].name: user,
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
-          enrollments.csrHost: network-org-3-peer-1.org-3
+          enrollments.csrHost: network-org-3-peer-1-hlf-peer.org-3
           toolbox.enabled: true
 
       - name: network-org-4-peer-1
@@ -210,13 +210,13 @@ deploy:
         setValues:
           nginx-ingress.enabled: true
           nginx-ingress.controller.scope.enabled: true
-          ca.caName: rcaOrg4
-          ca.host: network-org-4-peer-1-ca.org-4
-          ca.orderer.host: network-orderer-ca.orderer
-          peer.host: network-org-4-peer-1.org-4
+          hlf-ca.caName: rcaOrg4
+          hlf-ca.host: network-org-4-peer-1-hlf-ca.org-4
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
+          hlf-peer.host: network-org-4-peer-1-hlf-peer.org-4
           organization.id: MyOrg4MSP
           organization.name: MyOrg4
-          peer.peer.mspID: MyOrg4MSP
+          hlf-peer.peer.mspID: MyOrg4MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
@@ -225,13 +225,13 @@ deploy:
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member'\,'MyOrg3MSP.member'\,'MyOrg4MSP.member')
           appChannel.chaincodeName: mycc
           appChannel.chaincodeVersion: "1.0"
-          orderer.host: network-orderer.orderer
-          peer.peer.gossip.externalEndpoint: network-org-4-peer-1.org-4:7051  :{port}
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-peer.peer.gossip.externalEndpoint: network-org-4-peer-1-hlf-peer.org-4:7051  :{port}
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
           enrollments.creds[1].name: user,
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
-          enrollments.csrHost: network-org-4-peer-1.org-4
+          enrollments.csrHost: network-org-4-peer-1-hlf-peer.org-4
           toolbox.enabled: true

--- a/tools/skaffold-4orgs.yaml
+++ b/tools/skaffold-4orgs.yaml
@@ -44,14 +44,14 @@ deploy:
           image: substrafoundation/hlf-k8s
         setValues:
           nginx-ingress.enabled: true
-          peer.enabled: false
-          ca.caName: rcaOrderer
-          ca.host: network-orderer-ca.orderer
-          ca.orderer.host: network-orderer-ca.orderer
+          hlf-peer.enabled: false
+          hlf-ca.caName: rcaOrderer
+          hlf-ca.host: network-orderer-hlf-ca.orderer
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
           organization.id: MyOrdererMSP
           organization.name: MyOrderer
-          orderer.enabled: true
-          orderer.monitor.enabled: true
+          hlf-ord.enabled: true
+          hlf-ord.monitor.enabled: true
           # Add Org to system channel to allows them to adminstrate application channels
           systemChannel.organizations[0].org: MyOrg1
           systemChannel.organizations[0].configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrg.json
@@ -61,15 +61,15 @@ deploy:
           systemChannel.organizations[2].configUrl: network-org-3-peer-1-hlf-k8s-config-operator.org-3/config/configOrg.json
           systemChannel.organizations[3].org: MyOrg4
           systemChannel.organizations[3].configUrl: network-org-3-peer-1-hlf-k8s-config-operator.org-3/config/configOrg.json
-          orderer.host: network-orderer.orderer
-          orderer.ord.mspID: MyOrdererMSP
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-ord.ord.mspID: MyOrdererMSP
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs admin=true:ecert"
           enrollments.creds[1].name: user
           enrollments.creds[1].secret: pwd
           enrollments.creds[1].options: "--id.type orderer"
-          enrollments.csrHost: network-orderer.orderer
+          enrollments.csrHost: network-orderer-hlf-ord.orderer
           toolbox.enabled: true
 
       - name: network-org-1-peer-1
@@ -82,13 +82,13 @@ deploy:
         setValues:
           nginx-ingress.enabled: true
           nginx-ingress.controller.scope.enabled: true
-          ca.caName: rcaOrg1
-          ca.host: network-org-1-peer-1-ca.org-1
-          ca.orderer.host: network-orderer-ca.orderer
-          peer.host: network-org-1-peer-1.org-1
+          hlf-ca.caName: rcaOrg1
+          hlf-ca.host: network-org-1-peer-1-hlf-ca.org-1
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
+          hlf-peer.host: network-org-1-peer-1-hlf-peer.org-1
           organization.id: MyOrg1MSP
           organization.name: MyOrg1
-          peer.peer.mspID: MyOrg1MSP
+          hlf-peer.peer.mspID: MyOrg1MSP
           chaincodes[0].instantiate: true
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
@@ -114,15 +114,15 @@ deploy:
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member'\,'MyOrg3MSP.member'\,'MyOrg4MSP.member')
           appChannel.chaincodeName: mycc
           appChannel.chaincodeVersion: "1.0"
-          orderer.host: network-orderer.orderer
-          peer.peer.gossip.externalEndpoint: network-org-1-peer-1.org-1:7051
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-peer.peer.gossip.externalEndpoint: network-org-1-peer-1-hlf-peer.org-1:7051
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
           enrollments.creds[1].name: user,
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
-          enrollments.csrHost: network-org-1-peer-1.org-1
+          enrollments.csrHost: network-org-1-peer-1-hlf-peer.org-1
           toolbox.enabled: true
 
 
@@ -136,13 +136,13 @@ deploy:
         setValues:
           nginx-ingress.enabled: true
           nginx-ingress.controller.scope.enabled: true
-          ca.caName: rcaOrg2
-          ca.host: network-org-2-peer-1-ca.org-2
-          ca.orderer.host: network-orderer-ca.orderer
-          peer.host: network-org-2-peer-1.org-2
+          hlf-ca.caName: rcaOrg2
+          hlf-ca.host: network-org-2-peer-1-hlf-ca.org-2
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
+          hlf-peer.host: network-org-2-peer-1-hlf-peer.org-2
           organization.id: MyOrg2MSP
           organization.name: MyOrg2
-          peer.peer.mspID: MyOrg2MSP
+          hlf-peer.peer.mspID: MyOrg2MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
@@ -167,15 +167,15 @@ deploy:
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member'\,'MyOrg3MSP.member'\,'MyOrg4MSP.member')
           appChannel.chaincodeName: mycc
           appChannel.chaincodeVersion: "1.0"
-          orderer.host: network-orderer.orderer
-          peer.peer.gossip.externalEndpoint: network-org-2-peer-1.org-2:7051
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-peer.peer.gossip.externalEndpoint: network-org-2-peer-1-hlf-peer.org-2:7051
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
           enrollments.creds[1].name: user,
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
-          enrollments.csrHost: network-org-2-peer-1.org-2
+          enrollments.csrHost: network-org-2-peer-1-hlf-peer.org-2
           toolbox.enabled: true
 
 
@@ -189,13 +189,13 @@ deploy:
         setValues:
           nginx-ingress.enabled: true
           nginx-ingress.controller.scope.enabled: true
-          ca.caName: rcaOrg3
-          ca.host: network-org-3-peer-1-ca.org-3
-          ca.orderer.host: network-orderer-ca.orderer
-          peer.host: network-org-3-peer-1.org-3
+          hlf-ca.caName: rcaOrg3
+          hlf-ca.host: network-org-3-peer-1-hlf-ca.org-3
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
+          hlf-peer.host: network-org-3-peer-1-hlf-peer.org-3
           organization.id: MyOrg3MSP
           organization.name: MyOrg3
-          peer.peer.mspID: MyOrg3MSP
+          hlf-peer.peer.mspID: MyOrg3MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
@@ -220,15 +220,15 @@ deploy:
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member'\,'MyOrg3MSP.member'\,'MyOrg4MSP.member')
           appChannel.chaincodeName: mycc
           appChannel.chaincodeVersion: "1.0"
-          orderer.host: network-orderer.orderer
-          peer.peer.gossip.externalEndpoint: network-org-3-peer-1.org-3:7051
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-peer.peer.gossip.externalEndpoint: network-org-3-peer-1-hlf-peer.org-3:7051
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
           enrollments.creds[1].name: user,
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
-          enrollments.csrHost: network-org-3-peer-1.org-3
+          enrollments.csrHost: network-org-3-peer-1-hlf-peer.org-3
           toolbox.enabled: true
 
       - name: network-org-4-peer-1
@@ -241,13 +241,13 @@ deploy:
         setValues:
           nginx-ingress.enabled: true
           nginx-ingress.controller.scope.enabled: true
-          ca.caName: rcaOrg4
-          ca.host: network-org-4-peer-1-ca.org-4
-          ca.orderer.host: network-orderer-ca.orderer
-          peer.host: network-org-4-peer-1.org-4
+          hlf-ca.caName: rcaOrg4
+          hlf-ca.host: network-org-4-peer-1-hlf-ca.org-4
+          hlf-ca.orderer.host: network-orderer-hlf-ca.orderer
+          hlf-peer.host: network-org-4-peer-1-hlf-peer.org-4
           organization.id: MyOrg4MSP
           organization.name: MyOrg4
-          peer.peer.mspID: MyOrg4MSP
+          hlf-peer.peer.mspID: MyOrg4MSP
           chaincodes[0].name: mycc
           chaincodes[0].version: "1.0"
           chaincodes[0].src: https://github.com/SubstraFoundation/substra-chaincode/archive/master.tar.gz
@@ -272,13 +272,13 @@ deploy:
           appChannel.chaincodePolicy: OR('MyOrg1MSP.member'\,'MyOrg2MSP.member'\,'MyOrg3MSP.member'\,'MyOrg4MSP.member')
           appChannel.chaincodeName: mycc
           appChannel.chaincodeVersion: "1.0"
-          orderer.host: network-orderer.orderer
-          peer.peer.gossip.externalEndpoint: network-org-4-peer-1.org-4:7051
+          hlf-ord.host: network-orderer-hlf-ord.orderer
+          hlf-peer.peer.gossip.externalEndpoint: network-org-4-peer-1-hlf-peer.org-4:7051
           enrollments.creds[0].name: admin
           enrollments.creds[0].secret: adminpwd
           enrollments.creds[0].options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
           enrollments.creds[1].name: user,
           enrollments.creds[1].secret: pwd,
           enrollments.creds[1].options: "--id.type peer"
-          enrollments.csrHost: network-org-4-peer-1.org-4
+          enrollments.csrHost: network-org-4-peer-1-hlf-peer.org-4
           toolbox.enabled: true

--- a/tools/test-dev-network.sh
+++ b/tools/test-dev-network.sh
@@ -22,6 +22,6 @@ for i in `seq $1`; do
         --cafile /var/hyperledger/tls/ord/cert/cacert.pem \
         --certfile /var/hyperledger/tls/server/pair/tls.crt \
         --keyfile /var/hyperledger/tls/server/pair/tls.key \
-        -o network-orderer.orderer:7050 \
+        -o network-orderer-hlf-ord.orderer:7050 \
         -c '{\"Args\":[\"queryTraintuples\"]}'"
 done


### PR DESCRIPTION
Companion PR: https://github.com/SubstraFoundation/substra-backend/pull/246

Remove all aliases to avoid potential issue with helm issue with subchart aliases

You can deploy with skaffold (2, 3, 4 orgs) and test it with :

```bash
#!/bin/bash

for i in {1..4}; do
    kubectl exec -it -n org-$i `kubectl get pods -n org-$i | grep toolbox | cut -d' ' -f1` -- \
    bash -c "peer chaincode invoke \
        -C mychannel \
        -n mycc \
        --tls \
        --clientauth \
        --cafile /var/hyperledger/tls/ord/cert/cacert.pem \
        --certfile /var/hyperledger/tls/server/pair/tls.crt \
        --keyfile /var/hyperledger/tls/server/pair/tls.key \
        -o network-orderer-hlf-ord.orderer:7050 \
        -c '{\"Args\":[\"queryTraintuples\"]}'"
done

```