### PR TITLE
fix system channel present partner verification

### DIFF
--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 1.4.0
+version: 1.4.1
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/templates/deployment-system-channel-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-system-channel-operator.yaml
@@ -74,7 +74,7 @@ spec:
 
                 ## Check if update has been already sent
                 printf "[DEBUG] Check whether '$org' is in the system channel:\n"
-                configtxlator proto_decode --input channel-$org-hasjoined.block --type common.Block | jq .data.data[0].payload.data.config > channel-$org-hasjoined.json
+                configtxlator proto_decode --input channel.block --type common.Block | jq .data.data[0].payload.data.config > channel-$org-hasjoined.json
                 if grep "$mspid" channel-$org-hasjoined.json > /dev/null; then
                   printf "[DEBUG] $org is already in the system channel\n"
                   sleep 5


### PR DESCRIPTION
Before we where not looking in the correct file to check if a partner was already present in the system channel. So we executed the loop content even if the partner was already present.