### PR TITLE
Prevent from fetching ingress html

### DIFF
--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 1.4.1
+version: 1.4.2
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/templates/deployment-system-channel-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-system-channel-operator.yaml
@@ -97,7 +97,7 @@ spec:
                 ## Fetch organization configuration
                 until [ -f "configOrg-$org.json" ] && [ -s "configOrg-$org.json" ]; do
                   printf "[DEBUG] Fetch the organization ($org) configuration from $configUrl\n"
-                  curl -L --output ./configOrg-$org.json $configUrl
+                  curl --fail -L --output ./configOrg-$org.json $configUrl
                   sleep 3
                 done
 


### PR DESCRIPTION
Without the `--fail` flag when we download the config from the config-operator if the operator is not ready we can fetch an html page from nginx leading to an error in the proposal creation.
But because we downloaded the html page the system channel operator do not try to download a correct config on the next loop iteration.