### PR TITLE
Specify HLF chaincode images

### DIFF
--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 2.1.0
+version: 2.2.0
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -145,7 +145,10 @@ hlf-peer:
         enabled: "true"
       client:
         enabled: "true"
-
+    chaincode:
+      builder: hyperledger/fabric-ccenv:1.4.6
+      runtime:
+        golang: hyperledger/fabric-baseos:0.4.16
   enabled: true
   host: peer-hostname
   port: 7051


### PR DESCRIPTION
Follow-up to https://github.com/SubstraFoundation/hlf-k8s/pull/76

Fixes hlf-k8s being non-functional following the removal of `:latest` image(s) by hyperledger.