### PR TITLE
Switch from Helm2 to Helm3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,17 @@ addons:
     - name: helm
       confinement: classic
       channel: 3.2/stable
+  apt:
+    packages:
+      - python3-pip
+      - python3-setuptools
+
+install:
+  - pip3 install yamllint
 
 script:
   - helm lint charts/hlf-k8s
+  - 'yamllint -d "{extends: default, rules: {line-length: disable}}" $(git ls-files "skaffold.yaml" "k8s/*.yaml" "tools/*.yaml")'
 
 after_script:
   - 'if ! git diff --quiet --exit-code $TRAVIS_COMMIT_RANGE charts; then CHART_CHANGED="true"; else CHART_CHANGED="false"; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ addons:
   snaps:
     - name: helm
       confinement: classic
-      channel: 2.16/stable
-
-before_script:
-  - helm init --client-only
+      channel: 3.2/stable
 
 script:
   - helm lint charts/hlf-k8s

--- a/charts/hlf-k8s/CHANGELOG.md
+++ b/charts/hlf-k8s/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## 1.5.0
-
-- `appChannel` changed to `appChannels` (list)
-- `appChannel.name` renamed to `appChannels[].channelName`
-- `applicationChannelOperator.ingress` moved to `appChannels[].ingress`
-
 ## 3.0.0
 
 - Switched to Helm3
 - Added `hooks.serviceAccount.name` to specify the serviceAccount used by the post-delete hook `<release>-hook-delete-secrets`
 - Added `hooks.serviceAccount.namespace` to specify the serviceAccount namespace (this will also set `<release>-hook-delete-secrets` namespace)
+
+## 1.5.0
+
+- `appChannel` changed to `appChannels` (list)
+- `appChannel.name` renamed to `appChannels[].channelName`
+- `applicationChannelOperator.ingress` moved to `appChannels[].ingress`

--- a/charts/hlf-k8s/CHANGELOG.md
+++ b/charts/hlf-k8s/CHANGELOG.md
@@ -5,3 +5,9 @@
 - `appChannel` changed to `appChannels` (list)
 - `appChannel.name` renamed to `appChannels[].channelName`
 - `applicationChannelOperator.ingress` moved to `appChannels[].ingress`
+
+## 3.0.0
+
+- Switched to Helm3
+- Added `hooks.serviceAccount.name` to specify the serviceAccount used by the post-delete hook `<release>-hook-delete-secrets`
+- Added `hooks.serviceAccount.namespace` to specify the serviceAccount namespace (this will also set `<release>-hook-delete-secrets` namespace)

--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 2.3.1
+version: 3.0.0
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -101,7 +101,8 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `privateCa.configMap.name` | The name of the ConfigMap containing the private CA certificate | `private-ca` |
 | `privateCa.configMap.fileName` | The CA certificate filename within the ConfigMap | `private-ca.crt` |
 | `hooks.deleteSecrets.enabled` | If true, the secrets created by the chart will be automatically deleted when the chart is uninstalled | `true` |
-| `hooks.serviceAccount` | `serviceAccount` used for the post-delete hooks, must be able to delete secrets | `tiller` | 
+| `hooks.serviceAccount.name` | `serviceAccount` used for the post-delete hooks, must be able to delete secrets | `""` |
+| `hooks.serviceAccount.namespace` | namespace of the `serviceAccount` used for the post-delete hook, this will define the namespace in which the hook job run (if unset it will be replaced by the release namespace) | `""`
 | `toolbox.enabled` | If true, a "toolbox" pod will be created with pre-installed utilities and certificates | `false` |
 
 

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -101,6 +101,7 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `privateCa.configMap.name` | The name of the ConfigMap containing the private CA certificate | `private-ca` |
 | `privateCa.configMap.fileName` | The CA certificate filename within the ConfigMap | `private-ca.crt` |
 | `hooks.deleteSecrets.enabled` | If true, the secrets created by the chart will be automatically deleted when the chart is uninstalled | `true` |
+| `hooks.serviceAccount` | `serviceAccount` used for the post-delete hooks, must be able to delete secrets | `tiller` | 
 | `toolbox.enabled` | If true, a "toolbox" pod will be created with pre-installed utilities and certificates | `false` |
 
 

--- a/charts/hlf-k8s/templates/job-hook-delete-secrets.yaml
+++ b/charts/hlf-k8s/templates/job-hook-delete-secrets.yaml
@@ -26,15 +26,14 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded
-  namespace: kube-system # Since we delete the secrets after 'helm delete',
-                         # we need to use the Tiller SA in the kube-system
-                         # namespace
+  {{- if eq (default .Values.hooks.serviceAccount "") "tiller" }} # The tiller SA is located in the kube-system namespace
+  namespace: kube-system
+  {{- end }}
 spec:
   template:
     spec:
       restartPolicy: OnFailure
-      serviceAccountName: tiller  # Since we delete the secrets after
-                                  # 'helm delete', we need to use the Tiller SA
+      serviceAccountName: {{ .Values.hooks.serviceAccount }}
       containers:
       - name: fabric-tools
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/hlf-k8s/templates/job-hook-delete-secrets.yaml
+++ b/charts/hlf-k8s/templates/job-hook-delete-secrets.yaml
@@ -26,14 +26,12 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded
-  {{- if eq (default .Values.hooks.serviceAccount "") "tiller" }} # The tiller SA is located in the kube-system namespace
-  namespace: kube-system
-  {{- end }}
+  namespace: {{ .Values.hooks.serviceAccount.namespace | default .Release.Namespace | quote }}
 spec:
   template:
     spec:
       restartPolicy: OnFailure
-      serviceAccountName: {{ .Values.hooks.serviceAccount }}
+      serviceAccountName: {{ .Values.hooks.serviceAccount.name }}
       containers:
       - name: fabric-tools
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -305,8 +305,6 @@ hooks:
   # Service account used for the hooks, must not be part of the release and have the rights to delete secrets
   serviceAccount:
     name: ""
-    # Note that this will set the namespace of the deleteSecret hook as serviceAccounts are namespaced resources
-    # If empty the namespace will be set to the release namespace during render
     namespace: ""
   deleteSecrets:
     enabled: true

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -303,7 +303,11 @@ enrollments:
 
 hooks:
   # Service account used for the hooks, must not be part of the release and have the rights to delete secrets
-  serviceAccount: tiller
+  serviceAccount:
+    name: ""
+    # Note that this will set the namespace of the deleteSecret hook as serviceAccounts are namespaced resources
+    # If empty the namespace will be set to the release namespace during render
+    namespace: ""
   deleteSecrets:
     enabled: true
   uninstallChaincode:

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -302,6 +302,8 @@ enrollments:
   csrHost: service-hostname
 
 hooks:
+  # Service account used for the hooks, must not be part of the release and have the rights to delete secrets
+  serviceAccount: tiller
   deleteSecrets:
     enabled: true
   uninstallChaincode:

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,6 @@
+# K8s manifests
+
+These manifests are only used in the case of a local skaffold deployment.
+We need these service accounts because the Helm post-delete hooks we use needs the permission to delete secrets.
+
+If you want to deploy substra using plain helm and want to use the hooks to clean everything you can adapt these manifests to create a serviceAccount with the right permissions in your cluster.

--- a/k8s/serviceAccount-orderer.yaml
+++ b/k8s/serviceAccount-orderer.yaml
@@ -11,10 +11,10 @@ metadata:
   name: substra-delete-hook
   namespace: orderer
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs:
-    - delete
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -22,9 +22,9 @@ metadata:
   name: substra-delete-hook
   namespace: orderer
 subjects:
-- kind: ServiceAccount
-  name: substra-delete-hook
-  namespace: orderer
+  - kind: ServiceAccount
+    name: substra-delete-hook
+    namespace: orderer
 roleRef:
   kind: Role
   name: substra-delete-hook

--- a/k8s/serviceAccount-orderer.yaml
+++ b/k8s/serviceAccount-orderer.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: substra-delete-hook
+  namespace: orderer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: substra-delete-hook
+  namespace: orderer
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs:
+    - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: substra-delete-hook
+  namespace: orderer
+subjects:
+- kind: ServiceAccount
+  name: substra-delete-hook
+  namespace: orderer
+roleRef:
+  kind: Role
+  name: substra-delete-hook
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/serviceAccount-org-1.yaml
+++ b/k8s/serviceAccount-org-1.yaml
@@ -11,10 +11,10 @@ metadata:
   name: substra-delete-hook
   namespace: org-1
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs:
-    - delete
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -22,9 +22,9 @@ metadata:
   name: substra-delete-hook
   namespace: org-1
 subjects:
-- kind: ServiceAccount
-  name: substra-delete-hook
-  namespace: org-1
+  - kind: ServiceAccount
+    name: substra-delete-hook
+    namespace: org-1
 roleRef:
   kind: Role
   name: substra-delete-hook

--- a/k8s/serviceAccount-org-1.yaml
+++ b/k8s/serviceAccount-org-1.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: substra-delete-hook
+  namespace: org-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: substra-delete-hook
+  namespace: org-1
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs:
+    - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: substra-delete-hook
+  namespace: org-1
+subjects:
+- kind: ServiceAccount
+  name: substra-delete-hook
+  namespace: org-1
+roleRef:
+  kind: Role
+  name: substra-delete-hook
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/serviceAccount-org-2.yaml
+++ b/k8s/serviceAccount-org-2.yaml
@@ -11,10 +11,10 @@ metadata:
   name: substra-delete-hook
   namespace: org-2
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs:
-    - delete
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -22,9 +22,9 @@ metadata:
   name: substra-delete-hook
   namespace: org-2
 subjects:
-- kind: ServiceAccount
-  name: substra-delete-hook
-  namespace: org-2
+  - kind: ServiceAccount
+    name: substra-delete-hook
+    namespace: org-2
 roleRef:
   kind: Role
   name: substra-delete-hook

--- a/k8s/serviceAccount-org-2.yaml
+++ b/k8s/serviceAccount-org-2.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: substra-delete-hook
+  namespace: org-2
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: substra-delete-hook
+  namespace: org-2
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs:
+    - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: substra-delete-hook
+  namespace: org-2
+subjects:
+- kind: ServiceAccount
+  name: substra-delete-hook
+  namespace: org-2
+roleRef:
+  kind: Role
+  name: substra-delete-hook
+  apiGroup: rbac.authorization.k8s.io

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+---
 apiVersion: skaffold/v1beta13
 kind: Config
 build:
@@ -186,6 +186,6 @@ deploy:
   # Ref: https://github.com/GoogleContainerTools/skaffold/blob/master/pkg/skaffold/runner/new.go#L194-L215 (func getDeployer)
   kubectl:
     manifests:
-    - k8s/serviceAccount-orderer.yaml
-    - k8s/serviceAccount-org-1.yaml
-    - k8s/serviceAccount-org-2.yaml
+      - k8s/serviceAccount-orderer.yaml
+      - k8s/serviceAccount-org-1.yaml
+      - k8s/serviceAccount-org-2.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -183,7 +183,7 @@ deploy:
       install: ["--create-namespace"]
   # We create the serviceAccounts with the kubectl deployer to ensure the serviceAccounts will stay present for the Helm deletion hooks
   # By design Skaffold create and delete ressources in a fixed order (Helm > kubectl > kustomize)
-  # Ref: https://github.com/GoogleContainerTools/skaffold/blob/master/pkg/skaffold/runner/new.go#L194-L215 (func getDeployer)
+  # Ref: https://github.com/GoogleContainerTools/skaffold/blob/dedd545/pkg/skaffold/runner/new.go#L191-L214 (func getDeployer)
   kubectl:
     manifests:
       - k8s/serviceAccount-orderer.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -66,7 +66,7 @@ deploy:
           enrollments.csrHost: network-orderer-hlf-ord.orderer
           toolbox.enabled: true
           hooks.serviceAccount.name: substra-delete-hook
-          
+
       - name: network-org-1-peer-1
         chartPath: charts/hlf-k8s
         namespace: org-1

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -65,7 +65,8 @@ deploy:
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer-hlf-ord.orderer
           toolbox.enabled: true
-
+          hooks.serviceAccount: substra-delete-hook
+          
       - name: network-org-1-peer-1
         chartPath: charts/hlf-k8s
         namespace: org-1
@@ -137,7 +138,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1-hlf-peer.org-1
           toolbox.enabled: true
-
+          hooks.serviceAccount: substra-delete-hook
 
       - name: network-org-2-peer-1
         chartPath: charts/hlf-k8s
@@ -177,4 +178,11 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1-hlf-peer.org-2
           toolbox.enabled: true
-
+          hooks.serviceAccount: substra-delete-hook
+    flags:
+      install: ["--create-namespace"]
+  kubectl:
+    manifests:
+    - k8s/serviceAccount-orderer.yaml
+    - k8s/serviceAccount-org-1.yaml
+    - k8s/serviceAccount-org-2.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -65,7 +65,7 @@ deploy:
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer-hlf-ord.orderer
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
           
       - name: network-org-1-peer-1
         chartPath: charts/hlf-k8s
@@ -138,7 +138,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1-hlf-peer.org-1
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
 
       - name: network-org-2-peer-1
         chartPath: charts/hlf-k8s
@@ -178,9 +178,12 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1-hlf-peer.org-2
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
     flags:
       install: ["--create-namespace"]
+  # We create the serviceAccounts with the kubectl deployer to ensure the serviceAccounts will stay present for the Helm deletion hooks
+  # By design Skaffold create and delete ressources in a fixed order (Helm > kubectl > kustomize)
+  # Ref: https://github.com/GoogleContainerTools/skaffold/blob/master/pkg/skaffold/runner/new.go#L194-L215 (func getDeployer)
   kubectl:
     manifests:
     - k8s/serviceAccount-orderer.yaml

--- a/tools/k8s/serviceAccount-org-3.yaml
+++ b/tools/k8s/serviceAccount-org-3.yaml
@@ -11,10 +11,10 @@ metadata:
   name: substra-delete-hook
   namespace: org-3
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs:
-    - delete
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -22,9 +22,9 @@ metadata:
   name: substra-delete-hook
   namespace: org-3
 subjects:
-- kind: ServiceAccount
-  name: substra-delete-hook
-  namespace: org-3
+  - kind: ServiceAccount
+    name: substra-delete-hook
+    namespace: org-3
 roleRef:
   kind: Role
   name: substra-delete-hook

--- a/tools/k8s/serviceAccount-org-3.yaml
+++ b/tools/k8s/serviceAccount-org-3.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: substra-delete-hook
+  namespace: org-3
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: substra-delete-hook
+  namespace: org-3
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs:
+    - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: substra-delete-hook
+  namespace: org-3
+subjects:
+- kind: ServiceAccount
+  name: substra-delete-hook
+  namespace: org-3
+roleRef:
+  kind: Role
+  name: substra-delete-hook
+  apiGroup: rbac.authorization.k8s.io

--- a/tools/k8s/serviceAccount-org-4.yaml
+++ b/tools/k8s/serviceAccount-org-4.yaml
@@ -11,10 +11,10 @@ metadata:
   name: substra-delete-hook
   namespace: org-4
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs:
-    - delete
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -22,9 +22,9 @@ metadata:
   name: substra-delete-hook
   namespace: org-4
 subjects:
-- kind: ServiceAccount
-  name: substra-delete-hook
-  namespace: org-4
+  - kind: ServiceAccount
+    name: substra-delete-hook
+    namespace: org-4
 roleRef:
   kind: Role
   name: substra-delete-hook

--- a/tools/k8s/serviceAccount-org-4.yaml
+++ b/tools/k8s/serviceAccount-org-4.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: substra-delete-hook
+  namespace: org-4
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: substra-delete-hook
+  namespace: org-4
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs:
+    - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: substra-delete-hook
+  namespace: org-4
+subjects:
+- kind: ServiceAccount
+  name: substra-delete-hook
+  namespace: org-4
+roleRef:
+  kind: Role
+  name: substra-delete-hook
+  apiGroup: rbac.authorization.k8s.io

--- a/tools/skaffold-3orgs.yaml
+++ b/tools/skaffold-3orgs.yaml
@@ -17,7 +17,7 @@
 #   This is An hlf-k8s deployment with 3 organizations using the default
 #   application channel policy ("MAJORITY")
 #
-
+---
 apiVersion: skaffold/v1beta13
 kind: Config
 build:
@@ -241,7 +241,7 @@ deploy:
       install: ["--create-namespace"]
   kubectl:
     manifests:
-    - k8s/serviceAccount-orderer.yaml
-    - k8s/serviceAccount-org-1.yaml
-    - k8s/serviceAccount-org-2.yaml
-    - tools/k8s/serviceAccount-org-3.yaml
+      - k8s/serviceAccount-orderer.yaml
+      - k8s/serviceAccount-org-1.yaml
+      - k8s/serviceAccount-org-2.yaml
+      - tools/k8s/serviceAccount-org-3.yaml

--- a/tools/skaffold-3orgs.yaml
+++ b/tools/skaffold-3orgs.yaml
@@ -72,7 +72,7 @@ deploy:
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer-hlf-ord.orderer
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
 
       - name: network-org-1-peer-1
         chartPath: charts/hlf-k8s
@@ -127,7 +127,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1-hlf-peer.org-1
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
 
       - name: network-org-2-peer-1
         chartPath: charts/hlf-k8s
@@ -182,8 +182,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1-hlf-peer.org-2
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
-
+          hooks.serviceAccount.name: substra-delete-hook
 
       - name: network-org-3-peer-1
         chartPath: charts/hlf-k8s
@@ -237,7 +236,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-3-peer-1-hlf-peer.org-3
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
     flags:
       install: ["--create-namespace"]
   kubectl:

--- a/tools/skaffold-3orgs.yaml
+++ b/tools/skaffold-3orgs.yaml
@@ -72,6 +72,7 @@ deploy:
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer-hlf-ord.orderer
           toolbox.enabled: true
+          hooks.serviceAccount: substra-delete-hook
 
       - name: network-org-1-peer-1
         chartPath: charts/hlf-k8s
@@ -126,7 +127,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1-hlf-peer.org-1
           toolbox.enabled: true
-
+          hooks.serviceAccount: substra-delete-hook
 
       - name: network-org-2-peer-1
         chartPath: charts/hlf-k8s
@@ -181,6 +182,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1-hlf-peer.org-2
           toolbox.enabled: true
+          hooks.serviceAccount: substra-delete-hook
 
 
       - name: network-org-3-peer-1
@@ -235,3 +237,12 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-3-peer-1-hlf-peer.org-3
           toolbox.enabled: true
+          hooks.serviceAccount: substra-delete-hook
+    flags:
+      install: ["--create-namespace"]
+  kubectl:
+    manifests:
+    - k8s/serviceAccount-orderer.yaml
+    - k8s/serviceAccount-org-1.yaml
+    - k8s/serviceAccount-org-2.yaml
+    - tools/k8s/serviceAccount-org-3.yaml

--- a/tools/skaffold-4orgs-policy-any.yaml
+++ b/tools/skaffold-4orgs-policy-any.yaml
@@ -17,7 +17,7 @@
 #   This is An hlf-k8s deployment with 4 organizations using the "ANY"
 #   application channel policy. A chosen node (here MyOrg1) is responsible
 #   for adding all the other nodes to the application channel.
-
+---
 apiVersion: skaffold/v1beta13
 kind: Config
 build:
@@ -240,8 +240,8 @@ deploy:
       install: ["--create-namespace"]
   kubectl:
     manifests:
-    - k8s/serviceAccount-orderer.yaml
-    - k8s/serviceAccount-org-1.yaml
-    - k8s/serviceAccount-org-2.yaml
-    - tools/k8s/serviceAccount-org-3.yaml
-    - tools/k8s/serviceAccount-org-4.yaml
+      - k8s/serviceAccount-orderer.yaml
+      - k8s/serviceAccount-org-1.yaml
+      - k8s/serviceAccount-org-2.yaml
+      - tools/k8s/serviceAccount-org-3.yaml
+      - tools/k8s/serviceAccount-org-4.yaml

--- a/tools/skaffold-4orgs-policy-any.yaml
+++ b/tools/skaffold-4orgs-policy-any.yaml
@@ -66,6 +66,7 @@ deploy:
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer-hlf-ord.orderer
           toolbox.enabled: true
+          hooks.serviceAccount: substra-delete-hook
 
       - name: network-org-1-peer-1
         chartPath: charts/hlf-k8s
@@ -124,7 +125,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1-hlf-peer.org-1
           toolbox.enabled: true
-
+          hooks.serviceAccount: substra-delete-hook
 
       - name: network-org-2-peer-1
         chartPath: charts/hlf-k8s
@@ -160,7 +161,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1-hlf-peer.org-2
           toolbox.enabled: true
-
+          hooks.serviceAccount: substra-delete-hook
 
       - name: network-org-3-peer-1
         chartPath: charts/hlf-k8s
@@ -197,6 +198,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-3-peer-1-hlf-peer.org-3
           toolbox.enabled: true
+          hooks.serviceAccount: substra-delete-hook
 
       - name: network-org-4-peer-1
         chartPath: charts/hlf-k8s
@@ -233,3 +235,13 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-4-peer-1-hlf-peer.org-4
           toolbox.enabled: true
+          hooks.serviceAccount: substra-delete-hook
+    flags:
+      install: ["--create-namespace"]
+  kubectl:
+    manifests:
+    - k8s/serviceAccount-orderer.yaml
+    - k8s/serviceAccount-org-1.yaml
+    - k8s/serviceAccount-org-2.yaml
+    - tools/k8s/serviceAccount-org-3.yaml
+    - tools/k8s/serviceAccount-org-4.yaml

--- a/tools/skaffold-4orgs-policy-any.yaml
+++ b/tools/skaffold-4orgs-policy-any.yaml
@@ -66,7 +66,7 @@ deploy:
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer-hlf-ord.orderer
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
 
       - name: network-org-1-peer-1
         chartPath: charts/hlf-k8s
@@ -125,7 +125,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1-hlf-peer.org-1
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
 
       - name: network-org-2-peer-1
         chartPath: charts/hlf-k8s
@@ -161,7 +161,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1-hlf-peer.org-2
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
 
       - name: network-org-3-peer-1
         chartPath: charts/hlf-k8s
@@ -198,7 +198,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-3-peer-1-hlf-peer.org-3
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
 
       - name: network-org-4-peer-1
         chartPath: charts/hlf-k8s
@@ -235,7 +235,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-4-peer-1-hlf-peer.org-4
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
     flags:
       install: ["--create-namespace"]
   kubectl:

--- a/tools/skaffold-4orgs.yaml
+++ b/tools/skaffold-4orgs.yaml
@@ -17,7 +17,7 @@
 #   This is An hlf-k8s deployment with 4 organizations using the default
 #   application channel policy ("MAJORITY")
 #
-
+---
 apiVersion: skaffold/v1beta13
 kind: Config
 build:
@@ -324,8 +324,8 @@ deploy:
       install: ["--create-namespace"]
   kubectl:
     manifests:
-    - k8s/serviceAccount-orderer.yaml
-    - k8s/serviceAccount-org-1.yaml
-    - k8s/serviceAccount-org-2.yaml
-    - tools/k8s/serviceAccount-org-3.yaml
-    - tools/k8s/serviceAccount-org-4.yaml
+      - k8s/serviceAccount-orderer.yaml
+      - k8s/serviceAccount-org-1.yaml
+      - k8s/serviceAccount-org-2.yaml
+      - tools/k8s/serviceAccount-org-3.yaml
+      - tools/k8s/serviceAccount-org-4.yaml

--- a/tools/skaffold-4orgs.yaml
+++ b/tools/skaffold-4orgs.yaml
@@ -75,6 +75,7 @@ deploy:
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer-hlf-ord.orderer
           toolbox.enabled: true
+          hooks.serviceAccount: substra-delete-hook
 
       - name: network-org-1-peer-1
         chartPath: charts/hlf-k8s
@@ -135,7 +136,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1-hlf-peer.org-1
           toolbox.enabled: true
-
+          hooks.serviceAccount: substra-delete-hook
 
       - name: network-org-2-peer-1
         chartPath: charts/hlf-k8s
@@ -196,7 +197,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1-hlf-peer.org-2
           toolbox.enabled: true
-
+          hooks.serviceAccount: substra-delete-hook
 
       - name: network-org-3-peer-1
         chartPath: charts/hlf-k8s
@@ -257,6 +258,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-3-peer-1-hlf-peer.org-3
           toolbox.enabled: true
+          hooks.serviceAccount: substra-delete-hook
 
       - name: network-org-4-peer-1
         chartPath: charts/hlf-k8s
@@ -317,3 +319,13 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-4-peer-1-hlf-peer.org-4
           toolbox.enabled: true
+          hooks.serviceAccount: substra-delete-hook
+    flags:
+      install: ["--create-namespace"]
+  kubectl:
+    manifests:
+    - k8s/serviceAccount-orderer.yaml
+    - k8s/serviceAccount-org-1.yaml
+    - k8s/serviceAccount-org-2.yaml
+    - tools/k8s/serviceAccount-org-3.yaml
+    - tools/k8s/serviceAccount-org-4.yaml

--- a/tools/skaffold-4orgs.yaml
+++ b/tools/skaffold-4orgs.yaml
@@ -75,7 +75,7 @@ deploy:
           enrollments.creds[1].options: "--id.type orderer"
           enrollments.csrHost: network-orderer-hlf-ord.orderer
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
 
       - name: network-org-1-peer-1
         chartPath: charts/hlf-k8s
@@ -136,7 +136,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-1-peer-1-hlf-peer.org-1
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
 
       - name: network-org-2-peer-1
         chartPath: charts/hlf-k8s
@@ -197,7 +197,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-2-peer-1-hlf-peer.org-2
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
 
       - name: network-org-3-peer-1
         chartPath: charts/hlf-k8s
@@ -258,7 +258,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-3-peer-1-hlf-peer.org-3
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
 
       - name: network-org-4-peer-1
         chartPath: charts/hlf-k8s
@@ -319,7 +319,7 @@ deploy:
           enrollments.creds[1].options: "--id.type peer"
           enrollments.csrHost: network-org-4-peer-1-hlf-peer.org-4
           toolbox.enabled: true
-          hooks.serviceAccount: substra-delete-hook
+          hooks.serviceAccount.name: substra-delete-hook
     flags:
       install: ["--create-namespace"]
   kubectl:


### PR DESCRIPTION
## Helm chart
Switching from **Helm2** to **Helm3** no major change was done to the hlf-k8s Helm chart. The only modification needed was to change the post-delete Helm hook that we had to delete secrets created by the app.
There is no more Tiller since **Helm3** so we can't use the `tiller` `serviceAccount` for our post-delete hooks but we still need a `serviceAccount` with the permissions to delete Kubernetes secrets.
The service account used to delete the Kubernetes secrets is now a value that you can set to use your own service account.
> ℹ️ Note that the serviceAccount is a namespaced ressource and needs to be located in the same namespace as your deployment.

As there was no major change the chart is still compatible with **Helm2** even if **Helm3** will now be prefered for deployment and in the future compatibility with **Helm2** will not be guaranteed.

## Skaffold deployment

In order to accommodate for the breaking changes introduced by **Helm3** it was needed to make small modifications to the Skaffold deployment configuration.
It is now required to tell Helm to explicitly create the namespaces when deploying an application and also to add the creation of the `serviceAccount` needed by the post-delete Helm hook.
A kubectl deployment was used for this as it was not possible to put the  SA in the chart or it gets deleted before the hook start. Because Skaffold create and delete ressources in a fixed order (Helm > Kubectl > Kustomize), using a kubectl deployment, the SA gets deleted after the hook is finished.

## Travis
In this PR the version of Helm in Travis was also updated as we will now only support **Helm3**.