### PR TITLE
Lint yaml files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,17 @@ addons:
     - name: helm
       confinement: classic
       channel: 3.2/stable
+  apt:
+    packages:
+      - python3-pip
+      - python3-setuptools
+
+install:
+  - pip3 install yamllint
 
 script:
   - helm lint charts/hlf-k8s
+  - 'yamllint -d "{extends: default, rules: {line-length: disable}}" $(git ls-files "skaffold.yaml" "k8s/*.yaml" "tools/*.yaml")'
 
 after_script:
   - 'if ! git diff --quiet --exit-code $TRAVIS_COMMIT_RANGE charts; then CHART_CHANGED="true"; else CHART_CHANGED="false"; fi'

--- a/k8s/serviceAccount-orderer.yaml
+++ b/k8s/serviceAccount-orderer.yaml
@@ -11,10 +11,10 @@ metadata:
   name: substra-delete-hook
   namespace: orderer
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs:
-    - delete
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -22,9 +22,9 @@ metadata:
   name: substra-delete-hook
   namespace: orderer
 subjects:
-- kind: ServiceAccount
-  name: substra-delete-hook
-  namespace: orderer
+  - kind: ServiceAccount
+    name: substra-delete-hook
+    namespace: orderer
 roleRef:
   kind: Role
   name: substra-delete-hook

--- a/k8s/serviceAccount-org-1.yaml
+++ b/k8s/serviceAccount-org-1.yaml
@@ -11,10 +11,10 @@ metadata:
   name: substra-delete-hook
   namespace: org-1
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs:
-    - delete
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -22,9 +22,9 @@ metadata:
   name: substra-delete-hook
   namespace: org-1
 subjects:
-- kind: ServiceAccount
-  name: substra-delete-hook
-  namespace: org-1
+  - kind: ServiceAccount
+    name: substra-delete-hook
+    namespace: org-1
 roleRef:
   kind: Role
   name: substra-delete-hook

--- a/k8s/serviceAccount-org-2.yaml
+++ b/k8s/serviceAccount-org-2.yaml
@@ -11,10 +11,10 @@ metadata:
   name: substra-delete-hook
   namespace: org-2
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs:
-    - delete
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -22,9 +22,9 @@ metadata:
   name: substra-delete-hook
   namespace: org-2
 subjects:
-- kind: ServiceAccount
-  name: substra-delete-hook
-  namespace: org-2
+  - kind: ServiceAccount
+    name: substra-delete-hook
+    namespace: org-2
 roleRef:
   kind: Role
   name: substra-delete-hook

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+---
 apiVersion: skaffold/v1beta13
 kind: Config
 build:
@@ -186,6 +186,6 @@ deploy:
   # Ref: https://github.com/GoogleContainerTools/skaffold/blob/master/pkg/skaffold/runner/new.go#L194-L215 (func getDeployer)
   kubectl:
     manifests:
-    - k8s/serviceAccount-orderer.yaml
-    - k8s/serviceAccount-org-1.yaml
-    - k8s/serviceAccount-org-2.yaml
+      - k8s/serviceAccount-orderer.yaml
+      - k8s/serviceAccount-org-1.yaml
+      - k8s/serviceAccount-org-2.yaml

--- a/tools/k8s/serviceAccount-org-3.yaml
+++ b/tools/k8s/serviceAccount-org-3.yaml
@@ -11,10 +11,10 @@ metadata:
   name: substra-delete-hook
   namespace: org-3
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs:
-    - delete
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -22,9 +22,9 @@ metadata:
   name: substra-delete-hook
   namespace: org-3
 subjects:
-- kind: ServiceAccount
-  name: substra-delete-hook
-  namespace: org-3
+  - kind: ServiceAccount
+    name: substra-delete-hook
+    namespace: org-3
 roleRef:
   kind: Role
   name: substra-delete-hook

--- a/tools/k8s/serviceAccount-org-4.yaml
+++ b/tools/k8s/serviceAccount-org-4.yaml
@@ -11,10 +11,10 @@ metadata:
   name: substra-delete-hook
   namespace: org-4
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs:
-    - delete
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -22,9 +22,9 @@ metadata:
   name: substra-delete-hook
   namespace: org-4
 subjects:
-- kind: ServiceAccount
-  name: substra-delete-hook
-  namespace: org-4
+  - kind: ServiceAccount
+    name: substra-delete-hook
+    namespace: org-4
 roleRef:
   kind: Role
   name: substra-delete-hook

--- a/tools/skaffold-3orgs.yaml
+++ b/tools/skaffold-3orgs.yaml
@@ -17,7 +17,7 @@
 #   This is An hlf-k8s deployment with 3 organizations using the default
 #   application channel policy ("MAJORITY")
 #
-
+---
 apiVersion: skaffold/v1beta13
 kind: Config
 build:
@@ -241,7 +241,7 @@ deploy:
       install: ["--create-namespace"]
   kubectl:
     manifests:
-    - k8s/serviceAccount-orderer.yaml
-    - k8s/serviceAccount-org-1.yaml
-    - k8s/serviceAccount-org-2.yaml
-    - tools/k8s/serviceAccount-org-3.yaml
+      - k8s/serviceAccount-orderer.yaml
+      - k8s/serviceAccount-org-1.yaml
+      - k8s/serviceAccount-org-2.yaml
+      - tools/k8s/serviceAccount-org-3.yaml

--- a/tools/skaffold-4orgs-policy-any.yaml
+++ b/tools/skaffold-4orgs-policy-any.yaml
@@ -17,7 +17,7 @@
 #   This is An hlf-k8s deployment with 4 organizations using the "ANY"
 #   application channel policy. A chosen node (here MyOrg1) is responsible
 #   for adding all the other nodes to the application channel.
-
+---
 apiVersion: skaffold/v1beta13
 kind: Config
 build:
@@ -240,8 +240,8 @@ deploy:
       install: ["--create-namespace"]
   kubectl:
     manifests:
-    - k8s/serviceAccount-orderer.yaml
-    - k8s/serviceAccount-org-1.yaml
-    - k8s/serviceAccount-org-2.yaml
-    - tools/k8s/serviceAccount-org-3.yaml
-    - tools/k8s/serviceAccount-org-4.yaml
+      - k8s/serviceAccount-orderer.yaml
+      - k8s/serviceAccount-org-1.yaml
+      - k8s/serviceAccount-org-2.yaml
+      - tools/k8s/serviceAccount-org-3.yaml
+      - tools/k8s/serviceAccount-org-4.yaml

--- a/tools/skaffold-4orgs.yaml
+++ b/tools/skaffold-4orgs.yaml
@@ -17,7 +17,7 @@
 #   This is An hlf-k8s deployment with 4 organizations using the default
 #   application channel policy ("MAJORITY")
 #
-
+---
 apiVersion: skaffold/v1beta13
 kind: Config
 build:
@@ -324,8 +324,8 @@ deploy:
       install: ["--create-namespace"]
   kubectl:
     manifests:
-    - k8s/serviceAccount-orderer.yaml
-    - k8s/serviceAccount-org-1.yaml
-    - k8s/serviceAccount-org-2.yaml
-    - tools/k8s/serviceAccount-org-3.yaml
-    - tools/k8s/serviceAccount-org-4.yaml
+      - k8s/serviceAccount-orderer.yaml
+      - k8s/serviceAccount-org-1.yaml
+      - k8s/serviceAccount-org-2.yaml
+      - tools/k8s/serviceAccount-org-3.yaml
+      - tools/k8s/serviceAccount-org-4.yaml


### PR DESCRIPTION
As we added some yaml files to the repo it seems important to lint them to avoid mistakes and catch early indentation issues, empty values or anything else that could be missed by a human reviewer.