### PR TITLE
Update substra-chaincode tag

### DIFF
--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 4.0.0
+version: 4.0.1
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -135,7 +135,7 @@ appChannels:
         policy: "OR('Org1MSP.member','Org2MSP.member')"
         image:
           repository: substrafoundation/substra-chaincode
-          tag: hlf-2
+          tag: 0.1.0
           pullPolicy: IfNotPresent
 ```
 

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -106,7 +106,7 @@ appChannels:
   #   policy: "OR('Org1MSP.member','Org2MSP.member')"
   #   image:
   #     repository: substrafoundation/substra-chaincode
-  #     tag: hlf-2
+  #     tag: 0.1.0
   #     pullPolicy: IfNotPresent
 
   ingress:

--- a/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
@@ -65,7 +65,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
   organizations:
@@ -108,7 +108,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
   organizations:

--- a/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
@@ -65,7 +65,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
 
@@ -105,7 +105,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
 enrollments:

--- a/examples/2-orgs-policy-any/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any/values/org-1-peer-1.yaml
@@ -64,7 +64,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
   organizations:
@@ -107,7 +107,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
   organizations:

--- a/examples/2-orgs-policy-any/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any/values/org-2-peer-1.yaml
@@ -64,7 +64,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
 
@@ -104,7 +104,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
 enrollments:

--- a/examples/3-orgs-policy-majority/values/org-1-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-1-peer-1.yaml
@@ -64,7 +64,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
   organizations:

--- a/examples/3-orgs-policy-majority/values/org-2-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-2-peer-1.yaml
@@ -64,7 +64,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
   organizations:

--- a/examples/3-orgs-policy-majority/values/org-3-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-3-peer-1.yaml
@@ -65,7 +65,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
   organizations:

--- a/examples/4-orgs-policy-any/values/org-1-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-1-peer-1.yaml
@@ -65,7 +65,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
   organizations:

--- a/examples/4-orgs-policy-any/values/org-2-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-2-peer-1.yaml
@@ -65,7 +65,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
 enrollments:

--- a/examples/4-orgs-policy-any/values/org-3-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-3-peer-1.yaml
@@ -65,7 +65,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
 enrollments:

--- a/examples/4-orgs-policy-any/values/org-4-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-4-peer-1.yaml
@@ -65,7 +65,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
 enrollments:

--- a/examples/4-orgs-policy-majority/values/org-1-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-1-peer-1.yaml
@@ -64,7 +64,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
   organizations:

--- a/examples/4-orgs-policy-majority/values/org-2-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-2-peer-1.yaml
@@ -64,7 +64,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
   organizations:

--- a/examples/4-orgs-policy-majority/values/org-3-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-3-peer-1.yaml
@@ -64,7 +64,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
   organizations:

--- a/examples/4-orgs-policy-majority/values/org-4-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-4-peer-1.yaml
@@ -64,7 +64,7 @@ appChannels:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: hlf-2
+      tag: 0.1.0
       pullPolicy: IfNotPresent
 
   organizations:


### PR DESCRIPTION
Update substra-chaincode default tag to 0.1.0

@AlexandrePicosson Is it possible to remove substra-chaince image `hlf-2` tag in dockerhub ?