### PR TITLE
Allow the same chaincode to be used on multiple channels

### DIFF
--- a/charts/hlf-k8s/CHANGELOG.md
+++ b/charts/hlf-k8s/CHANGELOG.md
@@ -1,44 +1,32 @@
 # Changelog
 
-
 # 5.0.0
 
-Chaincode properties have been moved from `appChannels[].chaincodes[]` to `chaincodes[]`, which the exception of the `policy` and `name` fields.
-
-Example:
-
-```yaml
-chaincodes:
-  - name: mycc
-    address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.1
-      pullPolicy: IfNotPresent
-
-
-appChannels:
-- channelName: mychannel
-  chaincodes:
-  - name: mycc
-    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
-```
+- Add support for using the same chaincode on multiple channels.
+- This changes the structure of the `appChannels` value. Please see [`UPDGRADE.md`](./UPGRADE.md).
 
 ## 4.0.0
 
+- Bump hyperledger fabric to 2.x. Please update values accordingly.
+- Use couchdb instead of goleveldb
+- Remove docker dependency and add chaincode pod
 
-Peer use now couchdb as default instead of goleveldb
-Orderer is now under etcdraft type and not solo anymore
-Policies are mandatory and need to be set for : SystemChannel, Application and Channel
+## 3.0.2
 
+- Added `genesis.generate` (defaults to `true` - behavior unchanged)
 
-hlf-k8s appChannels field expose now :
- - application policies
- - channel policies
- - chaincodes, which is not isolated anymore
+## 3.0.1
 
-Rename images from hlf-k8s to fabric-tools and fabric-ca-tools
+- Bump `hlf-peer` chart to `v1.6.0`
 
-/!\ As we use TLS for chaincode and peer communications, you need to add chaincode fqdn in the csrHost of the CA enrollement
+## 3.0.0
+
+- Switched to Helm3
+- Added `hooks.serviceAccount.name` to specify the serviceAccount used by the post-delete hook `<release>-hook-delete-secrets`
+- Added `hooks.serviceAccount.namespace` to specify the serviceAccount namespace (this will also set `<release>-hook-delete-secrets` namespace)
+
+## 1.5.0
+
+- `appChannel` changed to `appChannels` (list)
+- `appChannel.name` renamed to `appChannels[].channelName`
+- `applicationChannelOperator.ingress` moved to `appChannels[].ingress`

--- a/charts/hlf-k8s/CHANGELOG.md
+++ b/charts/hlf-k8s/CHANGELOG.md
@@ -1,28 +1,44 @@
 # Changelog
 
 
+# 5.0.0
+
+Chaincode properties have been moved from `appChannels[].chaincodes[]` to `chaincodes[]`, which the exception of the `policy` and `name` fields.
+
+Example:
+
+```yaml
+chaincodes:
+  - name: mycc
+    address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
+
+appChannels:
+- channelName: mychannel
+  chaincodes:
+  - name: mycc
+    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+```
+
 ## 4.0.0
 
-- Bump hyperledger fabric to 2.x. Please update values accordingly.
-- Use couchdb instead of goleveldb
-- Remove docker dependency and add chaincode pod
 
-## 3.0.2
+Peer use now couchdb as default instead of goleveldb
+Orderer is now under etcdraft type and not solo anymore
+Policies are mandatory and need to be set for : SystemChannel, Application and Channel
 
-- Added `genesis.generate` (defaults to `true` - behavior unchanged)
 
-## 3.0.1
+hlf-k8s appChannels field expose now :
+ - application policies
+ - channel policies
+ - chaincodes, which is not isolated anymore
 
-- Bump `hlf-peer` chart to `v1.6.0`
+Rename images from hlf-k8s to fabric-tools and fabric-ca-tools
 
-## 3.0.0
-
-- Switched to Helm3
-- Added `hooks.serviceAccount.name` to specify the serviceAccount used by the post-delete hook `<release>-hook-delete-secrets`
-- Added `hooks.serviceAccount.namespace` to specify the serviceAccount namespace (this will also set `<release>-hook-delete-secrets` namespace)
-
-## 1.5.0
-
-- `appChannel` changed to `appChannels` (list)
-- `appChannel.name` renamed to `appChannels[].channelName`
-- `applicationChannelOperator.ingress` moved to `appChannels[].ingress`
+/!\ As we use TLS for chaincode and peer communications, you need to add chaincode fqdn in the csrHost of the CA enrollement

--- a/charts/hlf-k8s/CHANGELOG.md
+++ b/charts/hlf-k8s/CHANGELOG.md
@@ -15,7 +15,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 

--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 4.0.2
+version: 5.0.0
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 4.1.0
+version: 4.0.2
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 4.0.1
+version: 4.1.0
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -43,14 +43,14 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `appChannels[].proposalOrganizations` | The organizations to fetch signed application channel update proposals from. | `[]` |
 | `appChannels[].channelPolicies` | This value overrides the default HLF channel policy. | (defined in values.yaml) |
 | `appChannels[].appPolicies` | This value overrides the default HLF application policy. | (defined in values.yaml) |
-| `appChannels[].chaincode` | The chaincodes to install on the Peer. See [Install a chaincode](#install-a-chaincode). | (undefined) |
+| `appChannels[].chaincodes` | The chaincodes to install on the Peer. See [Install a chaincode](#install-a-chaincode). | `[]` |
 | `appChannels[].chaincodes[].name` | The name of the chaincode | (undefined) |
 | `appChannels[].chaincodes[].policy` | The chaincode policy for this channel | (undefined) |
 | `appChannels[].ingress.enabled` | If true, Ingress will be created for this application channel operator. | `false` |
 | `appChannels[].ingress.annotations` | Application channel operator ingress annotations | (undefined) |
 | `appChannels[].ingress.tls` | Application channel operator ingress TLS configuration | (undefined) |
 | `appChannels[].ingress.hosts` | Application channel operator ingress hosts | (undefined) |
-| `chaincodes` | The chaincodes to install on the peer | (undefined) |
+| `chaincodes` | The chaincodes to install on the peer | `[]` |
 | `chaincodes[].name` | The name of the chaincode | (undefined) |
 | `chaincodes[].version` | The chaincode version | (undefined) |
 | `chaincodes[].address` | The URL to the chaincode service | (undefined) |

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -43,19 +43,20 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `appChannels[].proposalOrganizations` | The organizations to fetch signed application channel update proposals from. | `[]` |
 | `appChannels[].channelPolicies` | This value overrides the default HLF channel policy. | (defined in values.yaml) |
 | `appChannels[].appPolicies` | This value overrides the default HLF application policy. | (defined in values.yaml) |
-| `appChannels[].chaincodes` | The chaincodes to install on the Peer. See [Install a chaincode](#install-a-chaincode). | `[]` |
 | `appChannels[].chaincodes[].name` | The name of the chaincode | (undefined) |
-| `appChannels[].chaincodes[].version` | The chaincode version | (undefined) |
-| `appChannels[].chaincodes[].address` | The URL to the chaincode service | (undefined) |
-| `appChannels[].chaincodes[].port` | The port to the chaincode service | (undefined) |
-| `appChannels[].chaincodes[].policy` | The chaincode policy | (undefined) |
-| `appChannels[].chaincodes[].image.repository` | `chaincode` image repository | (undefined) |
-| `appChannels[].chaincodes[].image.tag` | `chaincode` image tag | (undefined) |
-| `appChannels[].chaincodes[].image.pullPolicy` | Image pull policy | (undefined) |
+| `appChannels[].chaincodes[].policy` | The chaincode policy for this channel | (undefined) |
 | `appChannels[].ingress.enabled` | If true, Ingress will be created for this application channel operator. | `false` |
 | `appChannels[].ingress.annotations` | Application channel operator ingress annotations | (undefined) |
 | `appChannels[].ingress.tls` | Application channel operator ingress TLS configuration | (undefined) |
 | `appChannels[].ingress.hosts` | Application channel operator ingress hosts | (undefined) |
+| `chaincodes` | The chaincodes to install on the peer | (undefined) |
+| `chaincodes[].name` | The name of the chaincode | (undefined) |
+| `chaincodes[].version` | The chaincode version | (undefined) |
+| `chaincodes[].address` | The URL to the chaincode service | (undefined) |
+| `chaincodes[].port` | The port to the chaincode service | (undefined) |
+| `chaincodes[].image.repository` | `chaincode` image repository | (undefined) |
+| `chaincodes[].image.tag` | `chaincode` image tag | (undefined) |
+| `chaincodes[].image.pullPolicy` | Image pull policy | (undefined) |
 | `configOperator.ingress.enabled` | If true, Ingress will be created for the config operator. | `false` |
 | `configOperator.ingress.annotations` | Config operator ingress annotations | (undefined) |
 | `configOperator.ingress.tls` | Config operator ingress TLS configuration | (undefined) |

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -45,6 +45,7 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `appChannels[].appPolicies` | This value overrides the default HLF application policy. | (defined in values.yaml) |
 | `appChannels[].chaincodes` | The chaincodes to install on the Peer. See [Install a chaincode](#install-a-chaincode). | `[]` |
 | `appChannels[].chaincodes[].name` | The name of the chaincode | (undefined) |
+| `appChannels[].chaincodes[].version` | The chaincode version | (undefined) |
 | `appChannels[].chaincodes[].policy` | The chaincode policy for this channel | (undefined) |
 | `appChannels[].ingress.enabled` | If true, Ingress will be created for this application channel operator. | `false` |
 | `appChannels[].ingress.annotations` | Application channel operator ingress annotations | (undefined) |

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -142,6 +142,7 @@ appChannels:
     chaincodes:
       - name: mycc
         policy: "OR('Org1MSP.member','Org2MSP.member')"
+        version: "1.0"
 ```
 
 
@@ -169,15 +170,14 @@ Finally, modify deployment values to use your chaincode image:
 
 For instance with `substrafoundation/substra-chaincode:my-tag`
 ```yaml
-  chaincodes:
-  - address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
-    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: my-tag
+chaincodes:
+- address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+  name: mycc
+  port: 7052
+  version: "1.0"
+  image:
+    repository: substrafoundation/substra-chaincode
+    tag: my-tag
 ```
 
 ### Add an organization to the system channel

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -43,6 +43,7 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `appChannels[].proposalOrganizations` | The organizations to fetch signed application channel update proposals from. | `[]` |
 | `appChannels[].channelPolicies` | This value overrides the default HLF channel policy. | (defined in values.yaml) |
 | `appChannels[].appPolicies` | This value overrides the default HLF application policy. | (defined in values.yaml) |
+| `appChannels[].chaincode` | The chaincodes to install on the Peer. See [Install a chaincode](#install-a-chaincode). | (undefined) |
 | `appChannels[].chaincodes[].name` | The name of the chaincode | (undefined) |
 | `appChannels[].chaincodes[].policy` | The chaincode policy for this channel | (undefined) |
 | `appChannels[].ingress.enabled` | If true, Ingress will be created for this application channel operator. | `false` |
@@ -126,18 +127,21 @@ Install a chaincode on a peer using the following values.
 On a peer:
 
 ```yaml
+chaincodes:
+  - name: mycc
+    version: "1.0"
+    address: "chaincode-org-0-substra-chaincode-chaincode.org-0"
+    port: "7052"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
   - channelName: mychannel
     chaincodes:
       - name: mycc
-        version: "1.0"
-        address: "chaincode-org-0-substra-chaincode-chaincode.org-0"
-        port: "7052"
         policy: "OR('Org1MSP.member','Org2MSP.member')"
-        image:
-          repository: substrafoundation/substra-chaincode
-          tag: 0.1.0
-          pullPolicy: IfNotPresent
 ```
 
 

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -134,7 +134,7 @@ chaincodes:
     port: "7052"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/charts/hlf-k8s/UPGRADE.md
+++ b/charts/hlf-k8s/UPGRADE.md
@@ -24,6 +24,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+    version: "1.0"
 ```
 
 ## 4.0.0

--- a/charts/hlf-k8s/UPGRADE.md
+++ b/charts/hlf-k8s/UPGRADE.md
@@ -1,19 +1,18 @@
-# Changelog
+# Upgrade
 
 
-## 4.0.0
+## 4.x.x
 
 
-Peer use now couchdb as default instead of goleveldb
-Orderer is now under etcdraft type and not solo anymore
-Policies are mandatory and need to be set for : SystemChannel, Application and Channel
+- Peer use now couchdb as default instead of goleveldb
+- Orderer is now under etcdraft type and not solo anymore
+- Policies are mandatory and need to be set for : SystemChannel, Application and Channel
+- Rename images from hlf-k8s to fabric-tools and fabric-ca-tools
 
+The `chaincodes` field now exposes the list of chaincodes to be installed on the peer
 
-hlf-k8s appChannels field expose now :
- - application policies
- - channel policies
- - chaincodes, which is not isolated anymore
-
-Rename images from hlf-k8s to fabric-tools and fabric-ca-tools
+For each channel, the `appChannels[].chaincodes` field now exposes:
+ - the name of the chaincode(s) to install
+ - the application policy
 
 /!\ As we use TLS for chaincode and peer communications, you need to add chaincode fqdn in the csrHost of the CA enrollement

--- a/charts/hlf-k8s/UPGRADE.md
+++ b/charts/hlf-k8s/UPGRADE.md
@@ -1,6 +1,6 @@
 # Upgrade
 
-## 4.x.x
+## 4.0.0
 
 - Peer use now couchdb as default instead of goleveldb
 - Orderer is now under etcdraft type and not solo anymore

--- a/charts/hlf-k8s/UPGRADE.md
+++ b/charts/hlf-k8s/UPGRADE.md
@@ -1,16 +1,44 @@
-# Upgrade
+# Changelog
+
+
+# 5.0.0
+
+Chaincode properties have been moved from `appChannels[].chaincodes[]` to `chaincodes[]`, which the exception of the `policy` and `name` fields.
+
+Example:
+
+```yaml
+chaincodes:
+  - name: mycc
+    address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.1
+      pullPolicy: IfNotPresent
+
+
+appChannels:
+- channelName: mychannel
+  chaincodes:
+  - name: mycc
+    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+```
 
 ## 4.0.0
 
-- Peer use now couchdb as default instead of goleveldb
-- Orderer is now under etcdraft type and not solo anymore
-- Policies are mandatory and need to be set for : SystemChannel, Application and Channel
-- Rename images from hlf-k8s to fabric-tools and fabric-ca-tools
 
-The `chaincodes` field now exposes the list of chaincodes to be installed on the peer
+Peer use now couchdb as default instead of goleveldb
+Orderer is now under etcdraft type and not solo anymore
+Policies are mandatory and need to be set for : SystemChannel, Application and Channel
 
-For each channel, the `appChannels[].chaincodes` field now exposes:
- - the name of the chaincode(s) to install
- - the application policy
+
+hlf-k8s appChannels field expose now :
+ - application policies
+ - channel policies
+ - chaincodes, which is not isolated anymore
+
+Rename images from hlf-k8s to fabric-tools and fabric-ca-tools
 
 /!\ As we use TLS for chaincode and peer communications, you need to add chaincode fqdn in the csrHost of the CA enrollement

--- a/charts/hlf-k8s/UPGRADE.md
+++ b/charts/hlf-k8s/UPGRADE.md
@@ -1,8 +1,6 @@
 # Upgrade
 
-
 ## 4.x.x
-
 
 - Peer use now couchdb as default instead of goleveldb
 - Orderer is now under etcdraft type and not solo anymore

--- a/charts/hlf-k8s/UPGRADE.md
+++ b/charts/hlf-k8s/UPGRADE.md
@@ -3,7 +3,7 @@
 
 # 5.0.0
 
-Chaincode properties have been moved from `appChannels[].chaincodes[]` to `chaincodes[]`, which the exception of the `policy` and `name` fields.
+Chaincode properties have been moved from `appChannels[].chaincodes[]` to `chaincodes[]`, which the exception of the `policy`, `name` and `version` fields.
 
 Example:
 

--- a/charts/hlf-k8s/templates/deployment-appchannel-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-appchannel-operator.yaml
@@ -292,7 +292,7 @@ spec:
               {{/* Find associated chaincode */}}
               {{ $chaincode := "" }}
               {{- range $.Values.chaincodes }}
-                {{- if eq .name $cc.name }}
+                {{- if and (eq .name $cc.name) (eq .version $cc.version) }}
                   - {{ $chaincode = . }}
                 {{- end }}
               {{- end }}

--- a/charts/hlf-k8s/templates/deployment-appchannel-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-appchannel-operator.yaml
@@ -287,9 +287,19 @@ spec:
 
               ## CHAINCODES
 
-              {{- range .chaincodes }}
+              {{- range $ccName := .chaincodes }}
 
-              ## Wait readiness
+              {{/* Find associated chaincode */}}
+              {{ $chaincode := "" }}
+              {{- range $.Values.chaincodes }}
+                {{- if eq .name $ccName }}
+                  - {{ $chaincode = . }}
+                {{- end }}
+              {{- end }}
+
+              {{ with $chaincode }}
+
+              ## Wait readiness: {{ .name }}
 
               while true; do
 
@@ -318,7 +328,7 @@ spec:
 
               done
 
-              ## Commit chaincode
+              ## Commit chaincode {{ .name }}
 
               peer lifecycle chaincode querycommitted --channelID {{ $value.channelName }} > chaincode.{{ .name }}.list 2>&1
 
@@ -351,7 +361,7 @@ spec:
 
               fi
 
-              ## Init chaincode
+              ## Init chaincode {{ .name }}
 
               if [[ ! -e chaincode.{{ .name }}.init ]]; then
                   touch chaincode.{{ .name }}.init
@@ -376,6 +386,7 @@ spec:
 
               fi
 
+              {{ end }}
               {{ end }}
 
               sleep 10

--- a/charts/hlf-k8s/templates/deployment-appchannel-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-appchannel-operator.yaml
@@ -287,12 +287,12 @@ spec:
 
               ## CHAINCODES
 
-              {{- range $ccName := .chaincodes }}
+              {{- range $cc := .chaincodes }}
 
               {{/* Find associated chaincode */}}
               {{ $chaincode := "" }}
               {{- range $.Values.chaincodes }}
-                {{- if eq .name $ccName }}
+                {{- if eq .name $cc.name }}
                   - {{ $chaincode = . }}
                 {{- end }}
               {{- end }}
@@ -307,7 +307,7 @@ spec:
                 printf "[DEBUG] Wait chaincode ready {{ .name }} {{ .version }} on channel {{ $value.channelName }}\n"
 
                 peer lifecycle chaincode checkcommitreadiness \
-                  --signature-policy "{{ .policy}}" \
+                  --signature-policy "{{ $cc.policy }}" \
                   --channelID {{ $value.channelName }} \
                   --name {{ .name }} \
                   --version {{ .version }} \
@@ -340,7 +340,7 @@ spec:
                 ENDORSEMENT=$(cat endorsement.config| tr '\n' ' ')
 
                 peer lifecycle chaincode commit \
-                  --signature-policy "{{ .policy}}" \
+                  --signature-policy "{{ $cc.policy }}" \
                   --channelID {{ $value.channelName }} \
                   --name {{ .name }} \
                   --version {{ .version }} \

--- a/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 {{- if index .Values "hlf-peer" "enabled" }}
-{{- range $index, $value :=.Values.appChannels }}
-{{- range .chaincodes }}
+{{- range .Values.chaincodes }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -122,14 +121,19 @@ spec:
 
                 ## Approve chaincode
 
+                {{ $chaincode := . }}
+                {{- range $channel := $.Values.appChannels }}
+                {{- if has $chaincode.name $channel.chaincodes }}
+
                 while true ; do
-                  printf "[DEBUG] Approving chaincode {{ .name }} {{ .version }} with ccid ${CHAINCODE_CCID}\n"
+
+                  printf "[DEBUG] Approving chaincode {{ $chaincode.name }} {{ $chaincode.version }} with ccid ${CHAINCODE_CCID} on channel {{ $channel.channelName }}\n"
 
                   peer lifecycle chaincode approveformyorg \
-                    --signature-policy "{{ .policy}}" \
-                    --channelID {{ $value.channelName }} \
-                    --name {{ .name }} \
-                    --version {{ .version }} \
+                    --signature-policy "{{ $chaincode.policy}}" \
+                    --channelID {{ $channel.channelName }} \
+                    --name {{ $chaincode.name }} \
+                    --version {{ $chaincode.version }} \
                     --package-id $CHAINCODE_CCID \
                     --sequence 1  \
                     --init-required \
@@ -141,8 +145,8 @@ spec:
                     -o {{ index $.Values "hlf-ord" "host" }}:{{ index $.Values "hlf-ord" "port" }} > /dev/null 2>&1
 
                   peer lifecycle chaincode queryapproved \
-                    --channelID {{ $value.channelName }} \
-                    --name {{ .name }} \
+                    --channelID {{ $channel.channelName }} \
+                    --name {{ $chaincode.name }} \
                     --sequence 1 \
                     --tls \
                     --clientauth \
@@ -156,11 +160,14 @@ spec:
                     break
                   fi
 
-                  printf "[DEBUG] Chaincode {{ .name }} {{ .version }} with ccid ${CHAINCODE_CCID} is not approved\n"
+                  printf "[DEBUG] Chaincode {{ .name }} {{ .version }} with ccid ${CHAINCODE_CCID} is not approved on channel {{ $channel.channelname }}\n"
 
                   sleep 5
 
                 done
+
+                {{- end }}
+                {{- end }}
 
                 sleep 10
               done
@@ -280,6 +287,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
@@ -124,7 +124,7 @@ spec:
                 {{ $chaincode := . }}
                 {{- range $channel := $.Values.appChannels }}
                 {{- range $channel.chaincodes }}
-                {{- if eq .name $chaincode.name }}
+                {{- if and (eq .name $chaincode.name) (eq .version $chaincode.version) }}
 
                 while true ; do
 

--- a/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
@@ -123,16 +123,17 @@ spec:
 
                 {{ $chaincode := . }}
                 {{- range $channel := $.Values.appChannels }}
-                {{- if has $chaincode.name $channel.chaincodes }}
+                {{- range $channel.chaincodes }}
+                {{- if eq .name $chaincode.name }}
 
                 while true ; do
 
-                  printf "[DEBUG] Approving chaincode {{ $chaincode.name }} {{ $chaincode.version }} with ccid ${CHAINCODE_CCID} on channel {{ $channel.channelName }}\n"
+                  printf "[DEBUG] Approving chaincode {{ .name }} {{ $chaincode.version }} with ccid ${CHAINCODE_CCID} on channel {{ $channel.channelName }}\n"
 
                   peer lifecycle chaincode approveformyorg \
-                    --signature-policy "{{ $chaincode.policy}}" \
+                    --signature-policy "{{ .policy}}" \
                     --channelID {{ $channel.channelName }} \
-                    --name {{ $chaincode.name }} \
+                    --name {{ .name }} \
                     --version {{ $chaincode.version }} \
                     --package-id $CHAINCODE_CCID \
                     --sequence 1  \
@@ -146,7 +147,7 @@ spec:
 
                   peer lifecycle chaincode queryapproved \
                     --channelID {{ $channel.channelName }} \
-                    --name {{ $chaincode.name }} \
+                    --name {{ .name }} \
                     --sequence 1 \
                     --tls \
                     --clientauth \
@@ -166,6 +167,7 @@ spec:
 
                 done
 
+                {{- end }}
                 {{- end }}
                 {{- end }}
 

--- a/charts/hlf-k8s/templates/deployment-chaincode.yaml
+++ b/charts/hlf-k8s/templates/deployment-chaincode.yaml
@@ -1,11 +1,10 @@
 {{- if index .Values "hlf-peer" "enabled" }}
-{{- range .Values.appChannels }}
-{{- range .chaincodes }}
+{{- range  .Values.chaincodes }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "substra.fullname" $ }}-chaincode-{{ .name}}
+  name: {{ template "substra.fullname" $ }}-chaincode-{{ .name }}
   labels:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
@@ -16,16 +15,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-        app.kubernetes.io/name: {{ template "substra.name" $ }}-chaincode-{{ .name}}
+        app.kubernetes.io/name: {{ template "substra.name" $ }}-chaincode-{{ .name }}
         app.kubernetes.io/instance: {{ $.Release.Name }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ template "substra.name" $ }}-chaincode-{{ .name}}
+        app.kubernetes.io/name: {{ template "substra.name" $ }}-chaincode-{{ .name }}
         app.kubernetes.io/instance: {{ $.Release.Name }}
     spec:
       containers:
-        - name: substra-chaincode-{{ .name}}
+        - name: substra-chaincode-{{ .name }}
           image: {{ .image.repository }}:{{ .image.tag }}
           imagePullPolicy: "{{ .image.pullPolicy }}"
           command: ['./chaincode']
@@ -61,12 +60,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "substra.fullname" $ }}-chaincode-{{ .name}}
+  name: {{ template "substra.fullname" $ }}-chaincode-{{ .name }}
   labels:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
-    app.kubernetes.io/name: {{ template "substra.name" $ }}-chaincode-{{ .name}}
+    app.kubernetes.io/name: {{ template "substra.name" $ }}-chaincode-{{ .name }}
 spec:
   type: ClusterIP
   ports:
@@ -75,8 +74,7 @@ spec:
     protocol: TCP
     targetPort: {{ .port }}
   selector:
-    app.kubernetes.io/name: {{ template "substra.name" $ }}-chaincode-{{ .name}}
+    app.kubernetes.io/name: {{ template "substra.name" $ }}-chaincode-{{ .name }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/hlf-k8s/templates/job-hook-delete-secrets.yaml
+++ b/charts/hlf-k8s/templates/job-hook-delete-secrets.yaml
@@ -102,10 +102,8 @@ spec:
           - secrets
           - -n
           - {{ .Release.Namespace }}
-          {{- range .Values.appChannels }}
-          {{- range .chaincodes }}
+          {{- range .Values.chaincodes }}
           - chaincode-ccid-{{ .name }}
-          {{- end }}
           {{- end }}
           - --ignore-not-found=true
           - --wait=true

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -60,7 +60,6 @@ systemChannel:
 #   version: "1.0"
 #   address: "chaincode-org-0-substra-chaincode-chaincode.org-0"
 #   port: "7052"
-#   policy: "OR('Org1MSP.member','Org2MSP.member')"
 #   image:
 #     repository: substrafoundation/substra-chaincode
 #     tag: 0.1.0
@@ -108,8 +107,9 @@ appChannels:
         Type: ImplicitMeta
         Rule: "MAJORITY Admins"
 
-  # chaincodes: [mycc]
   chaincodes: []
+  # - name: mycc
+  #   policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
 
   ingress:
     enabled: false

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -62,7 +62,7 @@ chaincodes: []
 #   port: "7052"
 #   image:
 #     repository: substrafoundation/substra-chaincode
-#     tag: 0.1.0
+#     tag: 0.1.1
 #     pullPolicy: IfNotPresent
 
 

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -55,7 +55,7 @@ systemChannel:
         Type: ImplicitMeta
         Rule: "MAJORITY Admins"
 
-# chaincodes:
+chaincodes: []
 # - name: mycc
 #   version: "1.0"
 #   address: "chaincode-org-0-substra-chaincode-chaincode.org-0"

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -55,6 +55,17 @@ systemChannel:
         Type: ImplicitMeta
         Rule: "MAJORITY Admins"
 
+# chaincodes:
+# - name: mycc
+#   version: "1.0"
+#   address: "chaincode-org-0-substra-chaincode-chaincode.org-0"
+#   port: "7052"
+#   policy: "OR('Org1MSP.member','Org2MSP.member')"
+#   image:
+#     repository: substrafoundation/substra-chaincode
+#     tag: 0.1.0
+#     pullPolicy: IfNotPresent
+
 
 appChannels:
 - channelName: mychannel
@@ -97,17 +108,8 @@ appChannels:
         Type: ImplicitMeta
         Rule: "MAJORITY Admins"
 
+  # chaincodes: [mycc]
   chaincodes: []
-  # -
-  #   name: mycc
-  #   version: "1.0"
-  #   address: "chaincode-org-0-substra-chaincode-chaincode.org-0"
-  #   port: "7052"
-  #   policy: "OR('Org1MSP.member','Org2MSP.member')"
-  #   image:
-  #     repository: substrafoundation/substra-chaincode
-  #     tag: 0.1.0
-  #     pullPolicy: IfNotPresent
 
   ingress:
     enabled: false

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -110,6 +110,7 @@ appChannels:
   chaincodes: []
   # - name: mycc
   #   policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+  #   version: "1.0"
 
   ingress:
     enabled: false

--- a/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
@@ -32,7 +32,6 @@ hlf-peer:
 chaincodes:
   - name: mycc
     address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
-    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
     port: 7052
     version: "1.0"
     image:
@@ -41,7 +40,6 @@ chaincodes:
       pullPolicy: IfNotPresent
   - name: yourcc
     address: network-org-1-peer-1-hlf-k8s-chaincode-yourcc.org-1
-    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
     port: 7052
     version: "1.0"
     image:
@@ -79,7 +77,9 @@ appChannels:
         Type: ImplicitMeta
         Rule: "ANY Admins"
 
-  chaincodes: [mycc]
+  chaincodes:
+  - name: mycc
+    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }
@@ -113,7 +113,9 @@ appChannels:
         Type: ImplicitMeta
         Rule: "ANY Admins"
 
-  chaincodes: [yourcc]
+  chaincodes:
+  - name: yourcc
+    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
@@ -36,7 +36,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
   - name: yourcc
     address: network-org-1-peer-1-hlf-k8s-chaincode-yourcc.org-1
@@ -44,7 +44,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 

--- a/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
@@ -28,6 +28,28 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+
+chaincodes:
+  - name: mycc
+    address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+  - name: yourcc
+    address: network-org-1-peer-1-hlf-k8s-chaincode-yourcc.org-1
+    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -57,16 +79,7 @@ appChannels:
         Type: ImplicitMeta
         Rule: "ANY Admins"
 
-  chaincodes:
-  - address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
-    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
+  chaincodes: [mycc]
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }
@@ -100,16 +113,7 @@ appChannels:
         Type: ImplicitMeta
         Rule: "ANY Admins"
 
-  chaincodes:
-  - address: network-org-1-peer-1-hlf-k8s-chaincode-yourcc.org-1
-    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
-    name: yourcc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
+  chaincodes: [yourcc]
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
@@ -80,6 +80,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+    version: "1.0"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }
@@ -116,6 +117,7 @@ appChannels:
   chaincodes:
   - name: yourcc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+    version: "1.0"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
@@ -80,6 +80,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+    version: "1.0"
 
 - channelName: yourchannel
   channelPolicies: |-
@@ -112,6 +113,7 @@ appChannels:
   chaincodes:
   - name: yourcc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+    version: "1.0"
 
 enrollments:
   creds:

--- a/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
@@ -28,6 +28,28 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+
+chaincodes:
+  - name: mycc
+    address: network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
+    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+  - name: yourcc
+    address: network-org-2-peer-1-hlf-k8s-chaincode-yourcc.org-2
+    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -57,17 +79,7 @@ appChannels:
         Type: ImplicitMeta
         Rule: "ANY Admins"
 
-  chaincodes:
-  - address: network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
-    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
-
+  chaincodes: [mycc]
 
 - channelName: yourchannel
   channelPolicies: |-
@@ -97,16 +109,7 @@ appChannels:
         Type: ImplicitMeta
         Rule: "ANY Admins"
 
-  chaincodes:
-  - address: network-org-2-peer-1-hlf-k8s-chaincode-yourcc.org-2
-    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
-    name: yourcc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
+  chaincodes: [yourcc]
 
 enrollments:
   creds:

--- a/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
@@ -32,7 +32,6 @@ hlf-peer:
 chaincodes:
   - name: mycc
     address: network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
-    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
     port: 7052
     version: "1.0"
     image:
@@ -41,7 +40,6 @@ chaincodes:
       pullPolicy: IfNotPresent
   - name: yourcc
     address: network-org-2-peer-1-hlf-k8s-chaincode-yourcc.org-2
-    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
     port: 7052
     version: "1.0"
     image:
@@ -79,7 +77,9 @@ appChannels:
         Type: ImplicitMeta
         Rule: "ANY Admins"
 
-  chaincodes: [mycc]
+  chaincodes:
+  - name: mycc
+    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
 
 - channelName: yourchannel
   channelPolicies: |-
@@ -109,7 +109,9 @@ appChannels:
         Type: ImplicitMeta
         Rule: "ANY Admins"
 
-  chaincodes: [yourcc]
+  chaincodes:
+  - name: yourcc
+    policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
 
 enrollments:
   creds:

--- a/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
@@ -36,7 +36,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
   - name: yourcc
     address: network-org-2-peer-1-hlf-k8s-chaincode-yourcc.org-2
@@ -44,7 +44,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 

--- a/examples/2-orgs-policy-any/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any/values/org-1-peer-1.yaml
@@ -34,7 +34,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
   - name: yourcc
     address: network-org-1-peer-1-hlf-k8s-chaincode-yourcc.org-1
@@ -42,7 +42,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/examples/2-orgs-policy-any/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any/values/org-1-peer-1.yaml
@@ -77,6 +77,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+    version: "1.0"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }
@@ -113,6 +114,7 @@ appChannels:
   chaincodes:
   - name: yourcc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+    version: "1.0"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/2-orgs-policy-any/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any/values/org-1-peer-1.yaml
@@ -27,6 +27,24 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+chaincodes:
+  - name: mycc
+    address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+  - name: yourcc
+    address: network-org-1-peer-1-hlf-k8s-chaincode-yourcc.org-1
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -57,15 +75,8 @@ appChannels:
         Rule: "ANY Admins"
 
   chaincodes:
-  - address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+  - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }
@@ -100,15 +111,8 @@ appChannels:
         Rule: "ANY Admins"
 
   chaincodes:
-  - address: network-org-1-peer-1-hlf-k8s-chaincode-yourcc.org-1
+  - name: yourcc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
-    name: yourcc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/2-orgs-policy-any/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any/values/org-2-peer-1.yaml
@@ -34,7 +34,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
   - name: yourcc
     address: network-org-2-peer-1-hlf-k8s-chaincode-yourcc.org-2
@@ -42,7 +42,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/examples/2-orgs-policy-any/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any/values/org-2-peer-1.yaml
@@ -77,6 +77,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+    version: "1.0"
 
 - channelName: yourchannel
   channelPolicies: |-
@@ -109,6 +110,7 @@ appChannels:
   chaincodes:
   - name: yourcc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
+    version: "1.0"
 
 enrollments:
   creds:

--- a/examples/2-orgs-policy-any/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any/values/org-2-peer-1.yaml
@@ -27,6 +27,24 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+chaincodes:
+  - name: mycc
+    address: network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+  - name: yourcc
+    address: network-org-2-peer-1-hlf-k8s-chaincode-yourcc.org-2
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -57,16 +75,8 @@ appChannels:
         Rule: "ANY Admins"
 
   chaincodes:
-  - address: network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
+  - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
-
 
 - channelName: yourchannel
   channelPolicies: |-
@@ -97,15 +107,8 @@ appChannels:
         Rule: "ANY Admins"
 
   chaincodes:
-  - address: network-org-2-peer-1-hlf-k8s-chaincode-yourcc.org-2
+  - name: yourcc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member')"
-    name: yourcc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
 enrollments:
   creds:

--- a/examples/3-orgs-policy-majority/values/org-1-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-1-peer-1.yaml
@@ -69,6 +69,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member')"
+    version: "1.0"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/3-orgs-policy-majority/values/org-1-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-1-peer-1.yaml
@@ -27,6 +27,16 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+chaincodes:
+  - name: mycc
+    address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -57,15 +67,8 @@ appChannels:
         Rule: "MAJORITY Admins"
 
   chaincodes:
-  - address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+  - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/3-orgs-policy-majority/values/org-1-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-1-peer-1.yaml
@@ -34,7 +34,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/examples/3-orgs-policy-majority/values/org-2-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-2-peer-1.yaml
@@ -69,6 +69,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member')"
+    version: "1.0"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/3-orgs-policy-majority/values/org-2-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-2-peer-1.yaml
@@ -27,6 +27,16 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+chaincodes:
+  - name: mycc
+    address: network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -57,15 +67,8 @@ appChannels:
         Rule: "MAJORITY Admins"
 
   chaincodes:
-  - address: network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
+  - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/3-orgs-policy-majority/values/org-2-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-2-peer-1.yaml
@@ -34,7 +34,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/examples/3-orgs-policy-majority/values/org-3-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-3-peer-1.yaml
@@ -35,7 +35,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/examples/3-orgs-policy-majority/values/org-3-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-3-peer-1.yaml
@@ -70,6 +70,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member')"
+    version: "1.0"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/3-orgs-policy-majority/values/org-3-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-3-peer-1.yaml
@@ -28,6 +28,16 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+chaincodes:
+  - name: mycc
+    address: network-org-3-peer-1-hlf-k8s-chaincode-mycc.org-3
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -58,15 +68,8 @@ appChannels:
         Rule: "MAJORITY Admins"
 
   chaincodes:
-  - address: network-org-3-peer-1-hlf-k8s-chaincode-mycc.org-3
+  - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/4-orgs-policy-any/values/org-1-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-1-peer-1.yaml
@@ -35,7 +35,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/examples/4-orgs-policy-any/values/org-1-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-1-peer-1.yaml
@@ -70,6 +70,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
+    version: "1.0"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/4-orgs-policy-any/values/org-1-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-1-peer-1.yaml
@@ -28,6 +28,16 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+chaincodes:
+  - name: mycc
+    address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -58,15 +68,8 @@ appChannels:
         Rule: "ANY Admins"
 
   chaincodes:
-  - address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+  - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/4-orgs-policy-any/values/org-2-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-2-peer-1.yaml
@@ -35,7 +35,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/examples/4-orgs-policy-any/values/org-2-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-2-peer-1.yaml
@@ -70,6 +70,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
+    version: "1.0"
 
 enrollments:
   creds:

--- a/examples/4-orgs-policy-any/values/org-2-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-2-peer-1.yaml
@@ -28,6 +28,16 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+chaincodes:
+  - name: mycc
+    address: network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -58,15 +68,8 @@ appChannels:
         Rule: "ANY Admins"
 
   chaincodes:
-  - address: network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
+  - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
 enrollments:
   creds:

--- a/examples/4-orgs-policy-any/values/org-3-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-3-peer-1.yaml
@@ -35,7 +35,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/examples/4-orgs-policy-any/values/org-3-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-3-peer-1.yaml
@@ -70,6 +70,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
+    version: "1.0"
 
 enrollments:
   creds:

--- a/examples/4-orgs-policy-any/values/org-3-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-3-peer-1.yaml
@@ -28,6 +28,16 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+chaincodes:
+  - name: mycc
+    address: network-org-3-peer-1-hlf-k8s-chaincode-mycc.org-3
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -58,15 +68,8 @@ appChannels:
         Rule: "ANY Admins"
 
   chaincodes:
-  - address: network-org-3-peer-1-hlf-k8s-chaincode-mycc.org-3
+  - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
 enrollments:
   creds:

--- a/examples/4-orgs-policy-any/values/org-4-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-4-peer-1.yaml
@@ -35,7 +35,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/examples/4-orgs-policy-any/values/org-4-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-4-peer-1.yaml
@@ -70,6 +70,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
+    version: "1.0"
 
 enrollments:
   creds:

--- a/examples/4-orgs-policy-any/values/org-4-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-4-peer-1.yaml
@@ -28,6 +28,16 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+chaincodes:
+  - name: mycc
+    address: network-org-4-peer-1-hlf-k8s-chaincode-mycc.org-4
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -58,15 +68,8 @@ appChannels:
         Rule: "ANY Admins"
 
   chaincodes:
-  - address: network-org-4-peer-1-hlf-k8s-chaincode-mycc.org-4
+  - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
 enrollments:
   creds:

--- a/examples/4-orgs-policy-majority/values/org-1-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-1-peer-1.yaml
@@ -27,6 +27,16 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+chaincodes:
+  - name: mycc
+    address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -57,15 +67,8 @@ appChannels:
         Rule: "MAJORITY Admins"
 
   chaincodes:
-  - address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+  - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/4-orgs-policy-majority/values/org-1-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-1-peer-1.yaml
@@ -69,6 +69,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
+    version: "1.0"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/4-orgs-policy-majority/values/org-1-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-1-peer-1.yaml
@@ -34,7 +34,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/examples/4-orgs-policy-majority/values/org-2-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-2-peer-1.yaml
@@ -27,6 +27,16 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+chaincodes:
+  - name: mycc
+    address: network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -57,15 +67,8 @@ appChannels:
         Rule: "MAJORITY Admins"
 
   chaincodes:
-  - address: network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
+  - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/4-orgs-policy-majority/values/org-2-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-2-peer-1.yaml
@@ -69,6 +69,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
+    version: "1.0"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/4-orgs-policy-majority/values/org-2-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-2-peer-1.yaml
@@ -34,7 +34,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/examples/4-orgs-policy-majority/values/org-3-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-3-peer-1.yaml
@@ -69,6 +69,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
+    version: "1.0"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/4-orgs-policy-majority/values/org-3-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-3-peer-1.yaml
@@ -34,7 +34,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/examples/4-orgs-policy-majority/values/org-3-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-3-peer-1.yaml
@@ -27,6 +27,16 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+chaincodes:
+  - name: mycc
+    address: network-org-3-peer-1-hlf-k8s-chaincode-mycc.org-3
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -57,15 +67,8 @@ appChannels:
         Rule: "MAJORITY Admins"
 
   chaincodes:
-  - address: network-org-3-peer-1-hlf-k8s-chaincode-mycc.org-3
+  - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/4-orgs-policy-majority/values/org-4-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-4-peer-1.yaml
@@ -69,6 +69,7 @@ appChannels:
   chaincodes:
   - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
+    version: "1.0"
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }

--- a/examples/4-orgs-policy-majority/values/org-4-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-4-peer-1.yaml
@@ -34,7 +34,7 @@ chaincodes:
     version: "1.0"
     image:
       repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
+      tag: 0.1.1
       pullPolicy: IfNotPresent
 
 appChannels:

--- a/examples/4-orgs-policy-majority/values/org-4-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-4-peer-1.yaml
@@ -27,6 +27,16 @@ hlf-peer:
   discover-monitor:
     enabled: true
 
+chaincodes:
+  - name: mycc
+    address: network-org-4-peer-1-hlf-k8s-chaincode-mycc.org-4
+    port: 7052
+    version: "1.0"
+    image:
+      repository: substrafoundation/substra-chaincode
+      tag: 0.1.0
+      pullPolicy: IfNotPresent
+
 appChannels:
 - channelName: mychannel
   channelPolicies: |-
@@ -57,15 +67,8 @@ appChannels:
         Rule: "MAJORITY Admins"
 
   chaincodes:
-  - address: network-org-4-peer-1-hlf-k8s-chaincode-mycc.org-4
+  - name: mycc
     policy: "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')"
-    name: mycc
-    port: 7052
-    version: "1.0"
-    image:
-      repository: substrafoundation/substra-chaincode
-      tag: 0.1.0
-      pullPolicy: IfNotPresent
 
   organizations:
     - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }


### PR DESCRIPTION
Companion PR: 
- https://github.com/SubstraFoundation/substra-tests/pull/166

We currently don't support using the same chaincode on different channels.

This PR removes this limitation.

Sample use case: solo channels using the same chaincode as shared channels.