### PR TITLE
refactor chaincode operator

### DIFF
--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 5.0.2
+version: 5.1.0
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/templates/deployment-appchannel-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-appchannel-operator.yaml
@@ -173,16 +173,6 @@ spec:
                 if ! [ -s "configOrg-$org.json" ]; then
                   printf "[DEBUG] Fetch the organization ($org) configuration from $configUrl\n"
                   curl --fail -L --output ./configOrg-$org.json $configUrl || continue # continue to next org if curl fails
-
-                  if [ -s "configOrg-$org.json" ]; then
-                    printf "[DEBUG] Extract tls root certificate from the organization ($org) configuration file \n"
-                    jq -r .values.MSP.value.config.tls_root_certs[0] ./configOrg-$org.json | base64 -d > tlsRootCert-$org.crt
-
-                    printf "[DEBUG] Add the organization ($org) for endorsement \n"
-                    PEER_HOST=$(jq -r .values.AnchorPeers.value.anchor_peers[0].host configOrg-$org.json)
-                    PEER_PORT=$(jq -r .values.AnchorPeers.value.anchor_peers[0].port configOrg-$org.json)
-                    grep -qxF -e "--peerAddresses ${PEER_HOST}:${PEER_PORT} --tlsRootCertFiles tlsRootCert-$org.crt" endorsement.config || echo "--peerAddresses ${PEER_HOST}:${PEER_PORT} --tlsRootCertFiles tlsRootCert-$org.crt" >> endorsement.config
-                  fi
                 fi
 
                 ## Extract application channel configuration
@@ -283,114 +273,7 @@ spec:
                 sleep 5
 
               done < /config/application-organizations
-
-
-              ## CHAINCODES
-
-              {{- range $cc := .chaincodes }}
-
-              {{/* Find associated chaincode */}}
-              {{ $chaincode := "" }}
-              {{- range $.Values.chaincodes }}
-                {{- if and (eq .name $cc.name) (eq .version $cc.version) }}
-                  - {{ $chaincode = . }}
-                {{- end }}
-              {{- end }}
-
-              {{ with $chaincode }}
-
-              ## Wait readiness: {{ .name }}
-
-              while true; do
-
-                # Chaincode commit
-                printf "[DEBUG] Wait chaincode ready {{ .name }} {{ .version }} on channel {{ $value.channelName }}\n"
-
-                peer lifecycle chaincode checkcommitreadiness \
-                  --signature-policy "{{ $cc.policy }}" \
-                  --channelID {{ $value.channelName }} \
-                  --name {{ .name }} \
-                  --version {{ .version }} \
-                  --sequence 1 \
-                  --init-required \
-                  --tls \
-                  --clientauth \
-                  --cafile /var/hyperledger/tls/ord/cert/cacert.pem \
-                  --keyfile /var/hyperledger/tls/client/pair/tls.key \
-                  --certfile /var/hyperledger/tls/client/pair/tls.crt \
-                  -o {{ index $.Values "hlf-ord" "host" }}:{{ index $.Values "hlf-ord" "port" }} > chaincode.{{ .name }}.ready 2>&1
-
-                if ! grep "false" chaincode.{{ .name }}.ready > /dev/null; then
-                  break
-                fi
-
-                sleep 5
-
-              done
-
-              ## Commit chaincode {{ .name }}
-
-              peer lifecycle chaincode querycommitted --channelID {{ $value.channelName }} > chaincode.{{ .name }}.list 2>&1
-
-              if ! grep "{{ .name }}" chaincode.{{ .name }}.list | grep "{{ .version }}" > /dev/null; then
-
-                # Chaincode commit
-                printf "[DEBUG] Commit chaincode {{ .name }} {{ .version }} on channel {{ $value.channelName }}\n"
-
-                ENDORSEMENT=$(cat endorsement.config| tr '\n' ' ')
-
-                peer lifecycle chaincode commit \
-                  --signature-policy "{{ $cc.policy }}" \
-                  --channelID {{ $value.channelName }} \
-                  --name {{ .name }} \
-                  --version {{ .version }} \
-                  --sequence 1 --init-required \
-                  --tls \
-                  --clientauth \
-                  --cafile /var/hyperledger/tls/ord/cert/cacert.pem \
-                  --keyfile /var/hyperledger/tls/client/pair/tls.key \
-                  --certfile /var/hyperledger/tls/client/pair/tls.crt \
-                  -o {{ index $.Values "hlf-ord" "host" }}:{{ index $.Values "hlf-ord" "port" }} \
-                  $ENDORSEMENT > chaincode.{{ .name }}.commit 2>&1
-
-                cat chaincode.{{ .name }}.commit
-
-                peer lifecycle chaincode querycommitted --channelID {{ $value.channelName }} > chaincode.{{ .name }}.list 2>&1
-
-                sleep 5
-
-              fi
-
-              ## Init chaincode {{ .name }}
-
-              if [[ ! -e chaincode.{{ .name }}.init ]]; then
-                  touch chaincode.{{ .name }}.init
-              fi
-
-              if ! grep "already initialized" chaincode.{{ .name }}.init > /dev/null; then
-
-                printf "[DEBUG] Init chaincode {{ .name }} {{ .version }} on channel {{ $value.channelName }}\n"
-
-                peer chaincode invoke --isInit \
-                  --channelID {{ $value.channelName }} \
-                  --name {{ .name }} \
-                  --tls \
-                  --clientauth \
-                  --cafile /var/hyperledger/tls/ord/cert/cacert.pem \
-                  --keyfile /var/hyperledger/tls/client/pair/tls.key \
-                  --certfile /var/hyperledger/tls/client/pair/tls.crt \
-                  -o {{ index $.Values "hlf-ord" "host" }}:{{ index $.Values "hlf-ord" "port" }} \
-                  -c '{"Args":["Init"]}' > chaincode.{{ .name }}.init 2>&1
-
-                sleep 5
-
-              fi
-
-              {{ end }}
-              {{ end }}
-
               sleep 10
-
             done
         resources:
           {{- toYaml $.Values.resources | nindent 14 }}

--- a/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
@@ -122,9 +122,9 @@ spec:
 
                 CHAINCODE_CCID=$(jq '.installed_chaincodes[] | select(.label=="{{ .name }}")' chaincode.list | jq -r .package_id)
 
-                until kubectl get secret chaincode-ccid-{{ .name }} > /dev/null; do
-                    printf "[DEBUG] Create chaincode ccid secret for {{ .name }}\n"
-                    kubectl create secret generic chaincode-ccid-{{ .name }} --from-literal=ccid=$CHAINCODE_CCID
+                until kubectl get secret chaincode-ccid-{{ .name }}-{{ .version }} > /dev/null; do
+                    printf "[DEBUG] Create chaincode ccid secret for {{ .name }} {{ .version }}\n"
+                    kubectl create secret generic chaincode-ccid-{{ .name }}-{{ .version }} --from-literal=ccid=$CHAINCODE_CCID
                 done
 
 
@@ -137,13 +137,13 @@ spec:
 
                 while true ; do
 
-                  printf "[DEBUG] Approving chaincode {{ .name }} {{ $chaincode.version }} with ccid ${CHAINCODE_CCID} on channel {{ $channel.channelName }}\n"
+                  printf "[DEBUG] Approving chaincode {{ .name }} {{ .version }} with ccid ${CHAINCODE_CCID} on channel {{ $channel.channelName }}\n"
 
                   peer lifecycle chaincode approveformyorg \
                     --signature-policy "{{ .policy}}" \
                     --channelID {{ $channel.channelName }} \
                     --name {{ .name }} \
-                    --version {{ $chaincode.version }} \
+                    --version {{ .version }} \
                     --package-id $CHAINCODE_CCID \
                     --sequence 1  \
                     --init-required \
@@ -215,8 +215,8 @@ spec:
                   # Chaincode commit
                   printf "[DEBUG] Commit chaincode {{ .name }} {{ .version }} on channel {{ $channel.channelName }}\n"
 
-                  DISCOVERY_PEER=$(discover peers --channel=mychannel --server=network-org-1-peer-1-hlf-peer.org-1:7051 --tlsKey=/var/hyperledger/tls/client/pair/tls.key --tlsCert=/var/hyperledger/tls/client/pair/tls.crt --peerTLSCA=/var/hyperledger/tls/client/cert/cacert.pem --userKey=/var/hyperledger/msp/keystore/key.pem --userCert=/var/hyperledger/msp/signcerts/cert.pem --MSP MyOrg1MSP)
-                  DISCOVERY_CONFIG=$(discover config --channel=mychannel --server=network-org-1-peer-1-hlf-peer.org-1:7051 --tlsKey=/var/hyperledger/tls/client/pair/tls.key --tlsCert=/var/hyperledger/tls/client/pair/tls.crt --peerTLSCA=/var/hyperledger/tls/client/cert/cacert.pem --userKey=/var/hyperledger/msp/keystore/key.pem --userCert=/var/hyperledger/msp/signcerts/cert.pem --MSP MyOrg1MSP)
+                  DISCOVERY_PEER=$(discover peers --channel={{ $channel.channelName }} --server={{ index $.Values "hlf-peer" "host" }}:{{ index $.Values "hlf-peer" "port" }} --tlsKey=/var/hyperledger/tls/client/pair/tls.key --tlsCert=/var/hyperledger/tls/client/pair/tls.crt --peerTLSCA=/var/hyperledger/tls/client/cert/cacert.pem --userKey=/var/hyperledger/msp/keystore/key.pem --userCert=/var/hyperledger/msp/signcerts/cert.pem --MSP {{ $.Values.organization.id }})
+                  DISCOVERY_CONFIG=$(discover config --channel={{ $channel.channelName }} --server={{ index $.Values "hlf-peer" "host" }}:{{ index $.Values "hlf-peer" "port" }} --tlsKey=/var/hyperledger/tls/client/pair/tls.key --tlsCert=/var/hyperledger/tls/client/pair/tls.crt --peerTLSCA=/var/hyperledger/tls/client/cert/cacert.pem --userKey=/var/hyperledger/msp/keystore/key.pem --userCert=/var/hyperledger/msp/signcerts/cert.pem --MSP {{ $.Values.organization.id }})
 
                   ENDORSEMENT="";
 
@@ -228,20 +228,20 @@ spec:
                   done < <(echo "$DISCOVERY_PEER" | jq -r '.[].MSPID')
 
                   peer lifecycle chaincode commit \
-                      --signature-policy "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')" \
-                      --channelID mychannel \
-                      --name mycc \
-                      --version 1.0 \
+                      --signature-policy "{{ .policy }}" \
+                      --channelID {{ $channel.channelName  }} \
+                      --name {{ .name }} \
+                      --version {{ .version }} \
                       --sequence 1 --init-required \
                       --tls \
                       --clientauth \
                       --cafile /var/hyperledger/tls/ord/cert/cacert.pem \
                       --keyfile /var/hyperledger/tls/client/pair/tls.key \
                       --certfile /var/hyperledger/tls/client/pair/tls.crt \
-                      -o network-orderer-hlf-ord.orderer:7050 \
-                      $ENDORSEMENT 2>&1
+                      -o {{ index $.Values "hlf-ord" "host" }}:{{ index $.Values "hlf-ord" "port" }} \
+                      $ENDORSEMENT > chaincode.{{ .name }}-{{ .version }}.commit 2>&1
 
-                  cat chaincode.{{ .name }}.commit
+                  cat chaincode.{{ .name }}-{{ .version }}.commit
 
                   peer lifecycle chaincode querycommitted --channelID {{ $channel.channelName }} > chaincode.{{ .name }}.list 2>&1
 
@@ -252,11 +252,11 @@ spec:
 
                 ## Init chaincode
 
-                if [[ ! -e chaincode.{{ .name }}v{{ .version }}.init ]]; then
-                    touch chaincode.{{ .name }}v{{ .version }}.init
+                if [[ ! -e chaincode.{{ .name }}-{{ .version }}.init ]]; then
+                    touch chaincode.{{ .name }}-{{ .version }}.init
                 fi
 
-                if ! grep "already initialized" chaincode.{{ .name }}v{{ .version }}.init > /dev/null; then
+                if ! grep "already initialized" chaincode.{{ .name }}-{{ .version }}.init > /dev/null; then
 
                   printf "[DEBUG] Init chaincode {{ .name }} {{ .version }} on channel {{ $channel.channelName }}\n"
 
@@ -269,7 +269,7 @@ spec:
                     --keyfile /var/hyperledger/tls/client/pair/tls.key \
                     --certfile /var/hyperledger/tls/client/pair/tls.crt \
                     -o {{ index $.Values "hlf-ord" "host" }}:{{ index $.Values "hlf-ord" "port" }} \
-                    -c '{"Args":["Init"]}' > chaincode.{{ .name }}v{{ .version }}.init 2>&1
+                    -c '{"Args":["Init"]}' > chaincode.{{ .name }}-{{ .version }}.init 2>&1
 
                   sleep 5
 

--- a/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
@@ -215,18 +215,31 @@ spec:
                   # Chaincode commit
                   printf "[DEBUG] Commit chaincode {{ .name }} {{ .version }} on channel {{ $channel.channelName }}\n"
 
+                  DISCOVERY_PEER=$(discover peers --channel=mychannel --server=network-org-1-peer-1-hlf-peer.org-1:7051 --tlsKey=/var/hyperledger/tls/client/pair/tls.key --tlsCert=/var/hyperledger/tls/client/pair/tls.crt --peerTLSCA=/var/hyperledger/tls/client/cert/cacert.pem --userKey=/var/hyperledger/msp/keystore/key.pem --userCert=/var/hyperledger/msp/signcerts/cert.pem --MSP MyOrg1MSP)
+                  DISCOVERY_CONFIG=$(discover config --channel=mychannel --server=network-org-1-peer-1-hlf-peer.org-1:7051 --tlsKey=/var/hyperledger/tls/client/pair/tls.key --tlsCert=/var/hyperledger/tls/client/pair/tls.crt --peerTLSCA=/var/hyperledger/tls/client/cert/cacert.pem --userKey=/var/hyperledger/msp/keystore/key.pem --userCert=/var/hyperledger/msp/signcerts/cert.pem --MSP MyOrg1MSP)
+
+                  ENDORSEMENT="";
+
+                  while read -r mspId; do
+                      TLS_ROOT_CERT=$(echo "$DISCOVERY_CONFIG" | jq -r ".msps.${mspId}.tls_root_certs[0]");
+                      ENDPOINT=$(echo "$DISCOVERY_PEER" | jq -r ".[] | select( .MSPID == \"$mspId\" ) | .Endpoint");
+                      echo "${TLS_ROOT_CERT}" | base64 -d > "tlsroot-${mspId}.crt";
+                      ENDORSEMENT="${ENDORSEMENT} --peerAddresses=${ENDPOINT} --tlsRootCertFiles=tlsroot-${mspId}.crt";
+                  done < <(echo "$DISCOVERY_PEER" | jq -r '.[].MSPID')
+
                   peer lifecycle chaincode commit \
-                    --signature-policy "{{ .policy }}" \
-                    --channelID {{ $channel.channelName }} \
-                    --name {{ .name }} \
-                    --version {{ .version }} \
-                    --sequence 1 --init-required \
-                    --tls \
-                    --clientauth \
-                    --cafile /var/hyperledger/tls/ord/cert/cacert.pem \
-                    --keyfile /var/hyperledger/tls/client/pair/tls.key \
-                    --certfile /var/hyperledger/tls/client/pair/tls.crt \
-                    -o {{ index $.Values "hlf-ord" "host" }}:{{ index $.Values "hlf-ord" "port" }} 2>&1
+                      --signature-policy "OR('MyOrg1MSP.member','MyOrg2MSP.member','MyOrg3MSP.member','MyOrg4MSP.member')" \
+                      --channelID mychannel \
+                      --name mycc \
+                      --version 1.0 \
+                      --sequence 1 --init-required \
+                      --tls \
+                      --clientauth \
+                      --cafile /var/hyperledger/tls/ord/cert/cacert.pem \
+                      --keyfile /var/hyperledger/tls/client/pair/tls.key \
+                      --certfile /var/hyperledger/tls/client/pair/tls.crt \
+                      -o network-orderer-hlf-ord.orderer:7050 \
+                      $ENDORSEMENT 2>&1
 
                   cat chaincode.{{ .name }}.commit
 

--- a/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
@@ -62,7 +62,9 @@ spec:
                 sleep 5
               done
 
-              ## Install chaincode on peer
+
+              ## Install chaincode
+
               while true; do
 
                 peer lifecycle chaincode queryinstalled -O json > chaincode.list 2>/dev/null
@@ -125,6 +127,7 @@ spec:
                     kubectl create secret generic chaincode-ccid-{{ .name }} --from-literal=ccid=$CHAINCODE_CCID
                 done
 
+
                 ## Approve chaincode
 
                 {{ $chaincode := . }}
@@ -172,6 +175,92 @@ spec:
                   sleep 5
 
                 done
+
+
+                ## Check chaincode commit readiness
+
+                while true; do
+
+                  printf "[DEBUG] Check chaincode readiness {{ .name }} {{ .version }} on channel {{ $channel.channelName }}\n"
+
+                  peer lifecycle chaincode checkcommitreadiness \
+                    --signature-policy "{{ .policy }}" \
+                    --channelID {{ $channel.channelName }} \
+                    --name {{ .name }} \
+                    --version {{ .version }} \
+                    --sequence 1 \
+                    --init-required \
+                    --tls \
+                    --clientauth \
+                    --cafile /var/hyperledger/tls/ord/cert/cacert.pem \
+                    --keyfile /var/hyperledger/tls/client/pair/tls.key \
+                    --certfile /var/hyperledger/tls/client/pair/tls.crt \
+                    -o {{ index $.Values "hlf-ord" "host" }}:{{ index $.Values "hlf-ord" "port" }} > chaincode.{{ .name }}.ready 2>&1
+
+                  if ! grep "false" chaincode.{{ .name }}.ready > /dev/null; then
+                    break
+                  fi
+
+                  sleep 5
+
+                done
+
+
+                ## Commit chaincode
+
+                peer lifecycle chaincode querycommitted --channelID {{ $channel.channelName }} > chaincode.{{ .name }}.list 2>&1
+
+                if ! grep "{{ .name }}" chaincode.{{ .name }}.list | grep "{{ .version }}" > /dev/null; then
+
+                  # Chaincode commit
+                  printf "[DEBUG] Commit chaincode {{ .name }} {{ .version }} on channel {{ $channel.channelName }}\n"
+
+                  peer lifecycle chaincode commit \
+                    --signature-policy "{{ .policy }}" \
+                    --channelID {{ $channel.channelName }} \
+                    --name {{ .name }} \
+                    --version {{ .version }} \
+                    --sequence 1 --init-required \
+                    --tls \
+                    --clientauth \
+                    --cafile /var/hyperledger/tls/ord/cert/cacert.pem \
+                    --keyfile /var/hyperledger/tls/client/pair/tls.key \
+                    --certfile /var/hyperledger/tls/client/pair/tls.crt \
+                    -o {{ index $.Values "hlf-ord" "host" }}:{{ index $.Values "hlf-ord" "port" }} 2>&1
+
+                  cat chaincode.{{ .name }}.commit
+
+                  peer lifecycle chaincode querycommitted --channelID {{ $channel.channelName }} > chaincode.{{ .name }}.list 2>&1
+
+                  sleep 5
+
+                fi
+
+
+                ## Init chaincode
+
+                if [[ ! -e chaincode.{{ .name }}v{{ .version }}.init ]]; then
+                    touch chaincode.{{ .name }}v{{ .version }}.init
+                fi
+
+                if ! grep "already initialized" chaincode.{{ .name }}v{{ .version }}.init > /dev/null; then
+
+                  printf "[DEBUG] Init chaincode {{ .name }} {{ .version }} on channel {{ $channel.channelName }}\n"
+
+                  peer chaincode invoke --isInit \
+                    --channelID {{ $channel.channelName }} \
+                    --name {{ .name }} \
+                    --tls \
+                    --clientauth \
+                    --cafile /var/hyperledger/tls/ord/cert/cacert.pem \
+                    --keyfile /var/hyperledger/tls/client/pair/tls.key \
+                    --certfile /var/hyperledger/tls/client/pair/tls.crt \
+                    -o {{ index $.Values "hlf-ord" "host" }}:{{ index $.Values "hlf-ord" "port" }} \
+                    -c '{"Args":["Init"]}' > chaincode.{{ .name }}v{{ .version }}.init 2>&1
+
+                  sleep 5
+
+                fi
 
                 {{- end }}
                 {{- end }}

--- a/charts/hlf-k8s/templates/deployment-chaincode.yaml
+++ b/charts/hlf-k8s/templates/deployment-chaincode.yaml
@@ -32,7 +32,7 @@ spec:
             - name: CHAINCODE_CCID
               valueFrom:
                 secretKeyRef:
-                  name: chaincode-ccid-{{ .name }}
+                  name: chaincode-ccid-{{ .name }}-{{ .version }}
                   key: ccid
             - name: CHAINCODE_ADDRESS
               value: "0.0.0.0:{{ .port }}"

--- a/charts/hlf-k8s/templates/job-hook-delete-secrets.yaml
+++ b/charts/hlf-k8s/templates/job-hook-delete-secrets.yaml
@@ -103,7 +103,7 @@ spec:
           - -n
           - {{ .Release.Namespace }}
           {{- range .Values.chaincodes }}
-          - chaincode-ccid-{{ .name }}
+          - chaincode-ccid-{{ .name }}-{{ .version }}
           {{- end }}
           - --ignore-not-found=true
           - --wait=true


### PR DESCRIPTION
## Changes

This PR moves the following calls from the appchannel operator to the chaincode operator, which removes a bit of  code/complexity.

```
peer lifecycle chaincode checkcommitreadiness
peer lifecycle chaincode querycommitted
peer chaincode invoke --isInit
```

## Side note about explicit v.s. implicit options (Edit: Outdated, see comments below)

 I didn't have to use discovery (as [suggested here](https://github.com/SubstraFoundation/hlf-k8s/pull/102#issuecomment-734149787)) to obtain the peer address and the TLS root cert:

```
--peerAddresses ${PEER_HOST}:${PEER_PORT} 
--tlsRootCertFiles tlsRootCert-$org.crt
```
The reason why we don't need to specify these values is that they are the "default" values taken from `core.yaml` and `/var/hyperledger/tls/client/pair`.

Question : Is it cleaner to pass paramters explicitly (via `--peerAddresses` et `--tlsRootCertFiles`), or to use "default" values as described above?

In any event **the other `peer` calls in the chaincode operator (listed below) also don't specify `--peerAddresses` and `--tlsRootCertFile`**. That's not new from this PR.

```
peer lifecycle chaincode install
peer lifecycle chaincode approveformyorg
etc...
```

You can see [in the doc](https://hyperledger-fabric.readthedocs.io/en/release-2.2/commands/peerlifecycle.html) that these commands also support `--peerAddresses` and `--tlsRootCertFile` arguments (but our code uses defaults instead).

We might choose to pass these options explicitly everywhere, or to stick with using defaults as in this PR.

This can be addressed either as part of this PR, or separately. Please comment accordingly.