### PR TITLE
Update crshost to use *.org for potential new chaincodes

### DIFF
--- a/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml
@@ -129,7 +129,7 @@ enrollments:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
   # csrHost is set for peer and chaincodes communications
-  csrHost: network-org-1-peer-1-hlf-peer.org-1,network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1,network-org-1-peer-1-hlf-k8s-chaincode-yourcc.org-1
+  csrHost: "*.org-1"
 
 
 toolbox:

--- a/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any-no-ca/values/org-2-peer-1.yaml
@@ -120,7 +120,7 @@ enrollments:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
   # csrHost is set for peer and chaincodes communications
-  csrHost: network-org-2-peer-1-hlf-peer.org-2,network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2,network-org-2-peer-1-hlf-k8s-chaincode-yourcc.org-2
+  csrHost: "*.org-2"
 
 
 toolbox:

--- a/examples/2-orgs-policy-any/values/org-1-peer-1.yaml
+++ b/examples/2-orgs-policy-any/values/org-1-peer-1.yaml
@@ -126,7 +126,7 @@ enrollments:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
   # csrHost is set for peer and chaincodes communications
-  csrHost: network-org-1-peer-1-hlf-peer.org-1,network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1,network-org-1-peer-1-hlf-k8s-chaincode-yourcc.org-1
+  csrHost: "*.org-1"
 
 
 toolbox:

--- a/examples/2-orgs-policy-any/values/org-2-peer-1.yaml
+++ b/examples/2-orgs-policy-any/values/org-2-peer-1.yaml
@@ -117,7 +117,7 @@ enrollments:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
   # csrHost is set for peer and chaincodes communications
-  csrHost: network-org-2-peer-1-hlf-peer.org-2,network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2,network-org-2-peer-1-hlf-k8s-chaincode-yourcc.org-2
+  csrHost: "*.org-2"
 
 
 toolbox:

--- a/examples/3-orgs-policy-majority/values/org-1-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-1-peer-1.yaml
@@ -85,7 +85,7 @@ enrollments:
   creds:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
-  csrHost: network-org-1-peer-1-hlf-peer.org-1,network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+  csrHost: "*.org-1"
 
 
 toolbox:

--- a/examples/3-orgs-policy-majority/values/org-2-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-2-peer-1.yaml
@@ -86,7 +86,7 @@ enrollments:
   creds:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
-  csrHost: network-org-2-peer-1-hlf-peer.org-2,network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
+  csrHost: "*.org-2"
 
 
 toolbox:

--- a/examples/3-orgs-policy-majority/values/org-3-peer-1.yaml
+++ b/examples/3-orgs-policy-majority/values/org-3-peer-1.yaml
@@ -86,7 +86,7 @@ enrollments:
   creds:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
-  csrHost: network-org-3-peer-1-hlf-peer.org-3,network-org-3-peer-1-hlf-k8s-chaincode-mycc.org-3
+  csrHost: "*.org-3"
 
 
 toolbox:

--- a/examples/4-orgs-policy-any/values/org-1-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-1-peer-1.yaml
@@ -82,7 +82,7 @@ enrollments:
   creds:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
-  csrHost: network-org-1-peer-1-hlf-peer.org-1,network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+  csrHost: "*.org-1"
 
 
 toolbox:

--- a/examples/4-orgs-policy-any/values/org-2-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-2-peer-1.yaml
@@ -76,7 +76,7 @@ enrollments:
   creds:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
-  csrHost: network-org-2-peer-1-hlf-peer.org-2,network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
+  csrHost: "*.org-2"
 
 
 toolbox:

--- a/examples/4-orgs-policy-any/values/org-3-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-3-peer-1.yaml
@@ -76,7 +76,7 @@ enrollments:
   creds:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
-  csrHost: network-org-3-peer-1-hlf-peer.org-3,network-org-3-peer-1-hlf-k8s-chaincode-mycc.org-3
+  csrHost: "*.org-3"
 
 
 toolbox:

--- a/examples/4-orgs-policy-any/values/org-4-peer-1.yaml
+++ b/examples/4-orgs-policy-any/values/org-4-peer-1.yaml
@@ -76,7 +76,7 @@ enrollments:
   creds:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
-  csrHost: network-org-4-peer-1-hlf-peer.org-4,network-org-4-peer-1-hlf-k8s-chaincode-mycc.org-4
+  csrHost: "*.org-4"
 
 
 toolbox:

--- a/examples/4-orgs-policy-majority/values/org-1-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-1-peer-1.yaml
@@ -87,7 +87,7 @@ enrollments:
   creds:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
-  csrHost: network-org-1-peer-1-hlf-peer.org-1,network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
+  csrHost: "*.org-1"
 
 
 toolbox:

--- a/examples/4-orgs-policy-majority/values/org-2-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-2-peer-1.yaml
@@ -88,7 +88,7 @@ enrollments:
   creds:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
-  csrHost: network-org-2-peer-1-hlf-peer.org-2,network-org-2-peer-1-hlf-k8s-chaincode-mycc.org-2
+  csrHost: "*.org-2"
 
 
 toolbox:

--- a/examples/4-orgs-policy-majority/values/org-3-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-3-peer-1.yaml
@@ -87,7 +87,7 @@ enrollments:
   creds:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
-  csrHost: network-org-3-peer-1-hlf-peer.org-3,network-org-3-peer-1-hlf-k8s-chaincode-mycc.org-3
+  csrHost: "*.org-3"
 
 
 toolbox:

--- a/examples/4-orgs-policy-majority/values/org-4-peer-1.yaml
+++ b/examples/4-orgs-policy-majority/values/org-4-peer-1.yaml
@@ -87,7 +87,7 @@ enrollments:
   creds:
     - { name: admin, secret: adminpwd, options: "--id.attrs hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"}
     - { name: user, secret: pwd, options: "--id.type peer"}
-  csrHost: network-org-4-peer-1-hlf-peer.org-4,network-org-4-peer-1-hlf-k8s-chaincode-mycc.org-4
+  csrHost: "*.org-4"
 
 
 toolbox:


### PR DESCRIPTION
## Description
If a user add a new chaincode after deployment, he may run into issue because crshost for certificate is defined at the deployment. Use wildcard in the examples to show that we can generate certificate for a domain.

## Closes issue(s)
None

## Companion PRs
None

## How to test / repro
Launch one of the examples.

## Screenshots / Trace

## Changes include
- [x] Use wildcard for domain crshot definition

## Checklist
- [x] I have tested this code
- [x] Examples have been updated

## Other comments
None