### PR TITLE
Fix empty chaincode.list file in chaincode operator

### DIFF
--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 5.0.1
+version: 5.0.2
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
@@ -67,6 +67,12 @@ spec:
 
                 peer lifecycle chaincode queryinstalled -O json > chaincode.list 2>/dev/null
 
+                while ! [ -s chaincode.list ]; do
+                  printf "[DEBUG] chaincode.list file is empty, retry in 5s\n"
+                  sleep 5
+                  peer lifecycle chaincode queryinstalled -O json > chaincode.list 2>/dev/null
+                done
+
                 until jq -e '.installed_chaincodes[] | select(.label=="{{ .name }}")' chaincode.list > /dev/null; do
                   printf "[DEBUG] Chaincode {{ .name }} not installed\n"
                   printf "[DEBUG] Installing chaincode {{ .name }}\n"


### PR DESCRIPTION
## Changes

Querying the chaincode list as long as the `chaincode.list` file is empty.

## Description

With `netcat -z` you are only checking that something is listening at the specified address.
In my setup the peer is deployed in a kubernetes and accessed through an ingress which is an nginx proxy. If you query the endpoint `peer.xyz.com` there is a service listening, nginx, even if the peer is not started.
This is leading to an issue where on [line 68 of deployment-chaincode-operator](https://github.com/SubstraFoundation/hlf-k8s/blob/master/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml#L68) the file `chaincode.list` is empty.

Then `jq -e '.installed_chaincodes[] | select(.label=="{{ .name }}")' chaincode.list > /dev/null;` return code is 0, so we are effectively skipping the whole install loop.

this leads to an empty secret `chaincode-ccid-{{ .name }}` and there is no recovery from here, you need a manual interaction to delete the chaincode-ccid secret if you want it to get correctly populated when the peer is finally alive.