### PR TITLE
remove netcat dependency which seems included in base image

### DIFF
--- a/images/fabric-tools/Dockerfile
+++ b/images/fabric-tools/Dockerfile
@@ -2,7 +2,7 @@ FROM hyperledger/fabric-tools:2.2.1
 
 # Install curl and netcat
 RUN apk update && \
-  apk add curl netcat-openbsd vim
+  apk add curl vim
 
 # Install kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.6/bin/linux/amd64/kubectl && \


### PR DESCRIPTION
Clément reported an issue that he spotted during the upgrade of Healthchain project with the latest release. It seems that the netcat is not working anymore due to the fact the base image is already packaging netcat.