### PR TITLE
Disable docker socket mount on hlf-peer

### DIFF
--- a/charts/hlf-k8s/CHANGELOG.md
+++ b/charts/hlf-k8s/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 5.1.1
+
+### Fixed
+- moved `hlf-peer.docker.enabled` to `hlf-peer.peer.docker.enabled` to correctly disable docker socket mount.
+
 # 5.0.0
 
 - Add support for using the same chaincode on multiple channels.

--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 5.1.0
+version: 5.1.1
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/README.md
+++ b/charts/hlf-k8s/README.md
@@ -29,7 +29,7 @@ The following table lists the configurable parameters of the hlf-k8s chart and d
 | `hlf-peer.peer.couchdbInstance` | CouchDB chart name to use cdb-peer | `cdb-peer` |
 | `hlf-peer.host` | The Peers's host | `peer-hostname` |
 | `hlf-peer.port` | The Peers's port | `7051` |
-| `hlf-peer.docker.enabled` | If true, mount host docker socket in the peer container | `false` |
+| `hlf-peer.peer.docker.enabled` | If true, mount host docker socket in the peer container | `false` |
 | `hlf-peer.ingress.enabled` | If true, Ingress will be created for the Peer | `false` |
 | `hlf-peer.ingress.annotations` | Peer ingress annotations | (undefined) |
 | `hlf-peer.ingress.tls` | Peer ingress TLS configuration | (undefined) |

--- a/charts/hlf-k8s/values.yaml
+++ b/charts/hlf-k8s/values.yaml
@@ -184,10 +184,10 @@ hlf-ca:
     port: 7054
 
 hlf-peer:
-  docker:
-    enabled:
-      false
   peer:
+    docker:
+      enabled:
+        false
     databaseType: CouchDB
     couchdbInstance: cdb-peer
     gossip:


### PR DESCRIPTION
## Description
Moved the object `docker.enabled` under the `peer` key.

## Motivation and Context

The docker socket mount was still enabled as the `docker` object was misplaced.
Here is the related documentation: [hlf-peer chart documentation](https://github.com/owkin/charts/blob/afdb2fba2dad2104db2ee1a48b33ceb87cc07913/hlf-peer/README.md#configuration)

## How Has This Been Tested?
Launching the setup with skaffold.

Looking for docker in the resulting chart:
**Before**
```sh
helm template peer -f examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml charts/hlf-k8s | grep docker
  CORE_VM_ENDPOINT: unix:///host/var/run/docker.sock
        - name: dockersocket
            path: /var/run/docker.sock
            - mountPath: /host/var/run/docker.sock
              name: dockersocket
```
**After**
```sh
helm template peer -f examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml charts/hlf-k8s | grep docker
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.