### PR TITLE
Update hlf url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HLF k8s [![Helm](https://github.com/SubstraFoundation/hlf-k8s/workflows/Helm/badge.svg)](https://github.com/SubstraFoundation/hlf-k8s/actions?query=workflow%3AHelm)
 
-HLF-k8s is a network of [Hyperledger Fabric](https://hyperledger-fabric.readthedocs.io/en/release-1.4) orderers and peers forming a permissioned blockchain.
+HLF-k8s is a network of [Hyperledger Fabric](https://hyperledger-fabric.readthedocs.io/en/latest/) orderers and peers forming a permissioned blockchain.
 
 It is part of the [Substra project](https://github.com/SubstraFoundation/substra).
 


### PR DESCRIPTION
Update the url to hlf documentation in the readme as it is pointing to v.1.4 whereas v2.+ is now implemented.
I have used the `latest` version, but please let me know if it would be better to point towards any specific version