### PR TITLE
Fix chaincode commit phase in chaincode-operator

### DIFF
--- a/charts/hlf-k8s/CHANGELOG.md
+++ b/charts/hlf-k8s/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+# 6.2.1
+### Fixed
+- `jq` does not fail anymore on mspid containing a special character in the chaincode operator.
+- The condition to enter the chaincode commit process in the chaincode operator was always true, now we enter only if the chaincode is not already commited.
+
 # 6.2.0
 
 - Set persistence value for each service to true by default

--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 6.2.0
+version: 6.2.1
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml
@@ -203,7 +203,7 @@ spec:
 
                 peer lifecycle chaincode querycommitted --channelID {{ $channel.channelName }} > chaincode_{{ .name }}_{{ .version }}_{{ $channel.channelName }}.committed 2>&1
 
-                if ! grep "Name: {{ .name }}" chaincode_{{ .name }}_{{ .version }}_{{ $channel.channelName }}.committed | grep -q "Version: {{ .version }}" | grep -q "Sequence: {{ .sequence }}"; then
+                if ! grep "Name: {{ .name }}" chaincode_{{ .name }}_{{ .version }}_{{ $channel.channelName }}.committed | grep "Version: {{ .version }}" | grep -q "Sequence: {{ .sequence }}"; then
 
                   # Chaincode commit
                   printf "[DEBUG] Commit chaincode {{ .name }} {{ .version }} on channel {{ $channel.channelName }}\n"
@@ -214,7 +214,7 @@ spec:
                   ENDORSEMENT="";
 
                   while read -r mspId; do
-                      TLS_ROOT_CERT=$(echo "$DISCOVERY_CONFIG" | jq -r ".msps.${mspId}.tls_root_certs[0]");
+                      TLS_ROOT_CERT=$(echo "$DISCOVERY_CONFIG" | jq -r ".msps | .\"${mspId}\" | .tls_root_certs[0]");
                       ENDPOINT=$(echo "$DISCOVERY_PEER" | jq -r ".[] | select( .MSPID == \"$mspId\" ) | .Endpoint");
                       echo "${TLS_ROOT_CERT}" | base64 -d > "tlsroot-${mspId}.crt";
                       ENDORSEMENT="${ENDORSEMENT} --peerAddresses=${ENDPOINT} --tlsRootCertFiles=tlsroot-${mspId}.crt";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changed the condition to enter the commit phase in the chaincode operator. Now we should enter only if the `name`, `version` or `sequence` value change, or if there is no chaincode committed.
Changed a `jq` expression used to get the `TLS_ROOT_CERT` from the config to make it work if there is a special character in the `mspid`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In some scenario I was using a mspid containing a `-` and this was preventing the chaincode from being committed with the latest version of this chart, printing a `jq` error in the logs.
```plain
jq: error: syntax error, unexpected IDENT, expecting $end (Unix shell quoting issues?) at <top-level>, line 1:
 .msps.Orgnode-1MSP.tls_root_certs[0]
 jq: 1 compile error
```

During the resolution of this issue I noticed that the following condition was never resolving to `False` even when the chaincode was already committed leading to error logs as the sequence number was not incremented.
https://github.com/SubstraFoundation/hlf-k8s/blob/3c0e1b4bab077ba638477b847a972a870e1619a7/charts/hlf-k8s/templates/deployment-chaincode-operator.yaml#L206
The fact that it was never resolving to `False` was due to the `-q` option of grep that just exit with 0 if the pattern is found and 1 if not found. So the last grep never had any input string.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I tested the `jq` fix by changing the mspids in the `2-orgs-policy-any-no-ca` files to include a dash in the mspid (`MyOrg1MSP => MyOrg-001MSP`).

I tested the if condition by hand, here are the results:

```sh
# Show the content of the commited file for reference
bash-5.0# cat chaincode_mycc_1.0_mychannel.committed
go package net: GODEBUG setting forcing use of Go s resolver
Committed chaincode definitions on channel 'mychannel':
Name: mycc, Version: 1.0, Sequence: 1, Endorsement Plugin: escc, Validation Plugin: vscc

# Test the condition if nothing changed in the values
bash-5.0# if ! grep "Name: mycc" chaincode_mycc_1.0_mychannel.committed | grep "Version: 1.0" | grep -q "Sequence: 1"; then echo "Commit chaincode"; fi

# Test the condition if we change the sequence value
bash-5.0# if ! grep "Name: mycc" chaincode_mycc_1.0_mychannel.committed | grep "Version: 1.0" | grep -q "Sequence: 2"; then echo "Commit chaincode"; fi
Commit chaincode

# Test the condition if we change the version value
bash-5.0# if ! grep "Name: mycc" chaincode_mycc_1.0_mychannel.committed | grep "Version: 1.1" | grep -q "Sequence: 1"; then echo "Commit chaincode"; fi
Commit chaincode

# Test the condition if we change the chaincode name value
bash-5.0# if ! grep "Name: yourcc" chaincode_mycc_1.0_mychannel.committed | grep "Version: 1.1" | grep -q "Sequence: 1"; then echo "Commit chaincode"; fi
Commit chaincode
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.