### PR TITLE
reduce delay in app channel operator

### DIFF
--- a/charts/hlf-k8s/CHANGELOG.md
+++ b/charts/hlf-k8s/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 6.2.2
+
+- Reduce the delay between each "add organization" operation in the appchannel operator from 5 secs to 1 sec
 
 # 6.2.1
 ### Fixed

--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: hlf-k8s
 home: https://substra.org/
-version: 6.2.1
+version: 6.2.2
 description: Tolling package for Substra that configure the network
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/templates/deployment-appchannel-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-appchannel-operator.yaml
@@ -270,7 +270,7 @@ spec:
                   --certfile /var/hyperledger/tls/client/pair/tls.crt \
                   -o {{ index $.Values "hlf-ord" "host" }}:{{ index $.Values "hlf-ord" "port" }}
 
-                sleep 5
+                sleep 1
 
               done < /config/application-organizations
               sleep 10


### PR DESCRIPTION
Reduce the delay in the app channel operator between each addition of a organization to the app channel. This makes the network startup faster, especially when there are a lot of orgs.
