### PR TITLE
fix: appchannel incorrect behavior with overlapping channel names

### DIFF
--- a/charts/hlf-k8s/CHANGELOG.md
+++ b/charts/hlf-k8s/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 7.0.1
+### Fixed
+- The application channel operator doesn't misbehave anymore when a peer joins 2 channels with overlapping names
+
 # 7.0.0
 ### Changed
 - Charts using API v2 now, officially dropping support form Helm v2

--- a/charts/hlf-k8s/Chart.yaml
+++ b/charts/hlf-k8s/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: hlf-k8s
 description: Substra tools to configure the network
 type: application
-version: 7.0.0
+version: 7.0.1
 home: https://substra.org/
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/hlf-k8s/templates/deployment-appchannel-operator.yaml
+++ b/charts/hlf-k8s/templates/deployment-appchannel-operator.yaml
@@ -101,7 +101,7 @@ spec:
                 --certfile /var/hyperledger/tls/client/pair/tls.crt \
                 -o {{ index $.Values "hlf-ord" "host" }}:{{ index $.Values "hlf-ord" "port" }} > channel.list
 
-              until grep "{{ .channelName }}" channel.list > /dev/null; do
+              until grep "^{{ .channelName }}$" channel.list > /dev/null; do
 
                 printf "[DEBUG] Fetching application channel block\n"
                 peer channel fetch oldest channeljoin.block \


### PR DESCRIPTION
Fixes https://github.com/SubstraFoundation/hlf-k8s/issues/131
﻿
